### PR TITLE
feat: detect `$slots` usages in template

### DIFF
--- a/src/utils/parseTemplate.ts
+++ b/src/utils/parseTemplate.ts
@@ -2,6 +2,7 @@ import type { SFCDescriptor } from '@vue/compiler-sfc'
 import { compileTemplate } from '@vue/compiler-sfc'
 
 export function parseTemplate (id: string, descriptor: SFCDescriptor) {
+  const slots = []
   if (!descriptor.template) {
     return {
       slots: []
@@ -25,7 +26,21 @@ export function parseTemplate (id: string, descriptor: SFCDescriptor) {
     ]
   }
 
+  // Detect `$slots` usage
+  const $slots = template.source.matchAll(/\$slots\.([-\w]+)/g)
+  let $slot = $slots.next()
+  while (!$slot.done) {
+    slots.push({
+      name: $slot.value[1]
+    })
+    $slot = $slots.next()
+  }
+
+  // Detect `<slot>` usage
+  const slotsAst = findSlots(template.ast.children)
+  slots.push(...slotsAst)
+
   return {
-    slots: findSlots(template.ast?.children || [])
+    slots
   }
 }

--- a/src/utils/parseTemplate.ts
+++ b/src/utils/parseTemplate.ts
@@ -27,11 +27,11 @@ export function parseTemplate (id: string, descriptor: SFCDescriptor) {
   }
 
   // Detect `$slots` usage
-  const $slots = template.source.matchAll(/\$slots\.([-\w]+)/g)
+  const $slots = template.source.matchAll(/\$slots(\.([-_\w]+)|\[['"]([-_\w]+)['"]\])/g)
   let $slot = $slots.next()
   while (!$slot.done) {
     slots.push({
-      name: $slot.value[1]
+      name: $slot.value[2] || $slot.value[3]
     })
     $slot = $slots.next()
   }

--- a/test/basic-component.test.ts
+++ b/test/basic-component.test.ts
@@ -12,6 +12,7 @@ describe('Basic Component', async () => {
   test('Slots', () => {
     expect(slots).toEqual([
       { name: 'variable' },
+      { name: 'foo-bar' },
       { name: 'default' },
       { name: 'nuxt' }
     ])

--- a/test/basic-component.test.ts
+++ b/test/basic-component.test.ts
@@ -11,6 +11,7 @@ describe('Basic Component', async () => {
 
   test('Slots', () => {
     expect(slots).toEqual([
+      { name: 'variable' },
       { name: 'default' },
       { name: 'nuxt' }
     ])

--- a/test/fixtures/basic/components/BasicComponent.vue
+++ b/test/fixtures/basic/components/BasicComponent.vue
@@ -3,6 +3,8 @@
     <slot />
     <hr>
     <slot name="nuxt" />
+
+    <SomeComponent :prop="$slots.variable" />
   </div>
 </template>
 

--- a/test/fixtures/basic/components/BasicComponent.vue
+++ b/test/fixtures/basic/components/BasicComponent.vue
@@ -5,6 +5,7 @@
     <slot name="nuxt" />
 
     <SomeComponent :prop="$slots.variable" />
+    <SomeComponent :prop="$slots['foo-bar']" />
   </div>
 </template>
 


### PR DESCRIPTION
Detect slots using `$slots` variable in the template.

This will allow detecting Content specific slots using `<Markdown />` component.

```vue
<Markdown :use="$slots.foobar" />
<Markdown :use="$slots['foo-bar']" />
```

resolves #13
