### PR TITLE
feat(up): refactor and expose parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "ufo",
       "pathe",
       "defu",
-      "unplugin"
+      "unplugin",
+      "consola"
     ]
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
     "vue": "^3.2.45"
   },
   "build": {
+    "entries": [
+      {
+        "input": "./src/parser.ts",
+        "name": "parser"
+      }
+    ],
     "externals": [
       "#nuxt-component-meta",
       "ufo",

--- a/playground/components/TestComponent.vue
+++ b/playground/components/TestComponent.vue
@@ -39,4 +39,6 @@ defineProps({
 })
 
 const emit = defineEmits(['change', 'delete'])
+
+const test = {}
 </script>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -16,11 +16,17 @@ export default defineNuxtConfig({
       '~/components'
     ]
   },
+
   modules: [
     '@nuxt/content',
     'pinceau/nuxt',
     nuxtMetaModule as any
   ],
+
+  componentMeta: {
+    debug: 2
+  },
+
   pinceau: {
     followSymbolicLinks: false,
     componentMetaSupport: true

--- a/playground/package.json
+++ b/playground/package.json
@@ -2,10 +2,10 @@
   "private": true,
   "name": "nuxt-component-meta-playground",
   "devDependencies": {
-    "@nuxt/content": "npm:@nuxt/content-edge@latest",
-    "nuxt": "^3.0.0-rc.12",
+    "@nuxt/content": "^2.3.0",
+    "nuxt": "^3.0.0",
     "nuxt-component-meta": "*",
-    "pinceau": "latest"
+    "pinceau": "^0.8.9"
   },
   "scripts": {
     "dev": "nuxi dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,24 +28,24 @@ importers:
       '@nuxt/content': 2.2.2
       '@nuxt/module-builder': 0.2.1
       '@nuxt/test-utils': 3.0.0_vue@3.2.45
-      '@nuxtjs/eslint-config-typescript': 12.0.0_s5ps7njkmjlaqajutnox5ntcla
-      eslint: 8.29.0
-      nuxt: 3.0.0_s5ps7njkmjlaqajutnox5ntcla
+      '@nuxtjs/eslint-config-typescript': 12.0.0_f5jcydormhcqaoeadqwgqigppy
+      eslint: 8.30.0
+      nuxt: 3.0.0_f5jcydormhcqaoeadqwgqigppy
       release-it: 15.5.1
       vitest: 0.25.3
       vue: 3.2.45
 
   playground:
     specifiers:
-      '@nuxt/content': npm:@nuxt/content-edge@latest
-      nuxt: ^3.0.0-rc.12
+      '@nuxt/content': ^2.3.0
+      nuxt: ^3.0.0
       nuxt-component-meta: '*'
-      pinceau: latest
+      pinceau: ^0.8.9
     devDependencies:
-      '@nuxt/content': /@nuxt/content-edge/2.2.2-27822801.ef92b20
+      '@nuxt/content': 2.3.0
       nuxt: 3.0.0
       nuxt-component-meta: link:..
-      pinceau: 0.7.2
+      pinceau: 0.8.9
 
   test/fixtures/basic:
     specifiers:
@@ -346,6 +346,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.15.18:
+    resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64/0.15.16:
     resolution: {integrity: sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==}
     engines: {node: '>=12'}
@@ -355,14 +364,23 @@ packages:
     dev: true
     optional: true
 
-  /@eslint/eslintrc/1.3.3:
-    resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
+  /@esbuild/linux-loong64/0.15.18:
+    resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@eslint/eslintrc/1.4.0:
+    resolution: {integrity: sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
       espree: 9.4.1
-      globals: 13.18.0
+      globals: 13.19.0
       ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -372,8 +390,8 @@ packages:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array/0.11.7:
-    resolution: {integrity: sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==}
+  /@humanwhocodes/config-array/0.11.8:
+    resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -495,8 +513,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  /@nuxt/content-edge/2.2.2-27822801.ef92b20:
-    resolution: {integrity: sha512-SXOTqgHdDLOL8/tZJqhK7x4XZzVS0Pgw/SE7CUU031XOBnSQ2wq5RIbLY16KRw1FDuiM8sAajiO8kTzuHKtmgA==}
+  /@nuxt/content/2.2.2:
+    resolution: {integrity: sha512-qHkyeD0cVRjd+KJH82+V4Twn1QTJh43m9VGMjljLUvZVdFGxU/ZAe4gq0rdTbi8CtCZNvcR9vvNApYjOP1LNYA==}
     dependencies:
       '@nuxt/kit': 3.0.0
       consola: 2.15.3
@@ -541,18 +559,18 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nuxt/content/2.2.2:
-    resolution: {integrity: sha512-qHkyeD0cVRjd+KJH82+V4Twn1QTJh43m9VGMjljLUvZVdFGxU/ZAe4gq0rdTbi8CtCZNvcR9vvNApYjOP1LNYA==}
+  /@nuxt/content/2.3.0:
+    resolution: {integrity: sha512-7IudXOiycHXWxRDe7tWFwnIVT6bp0YG5O4wttCYYd7cvyjX3k6d3zD2j1IkjJMhfqU2PWQ/Wd+A2+oeiLNg3gA==}
     dependencies:
       '@nuxt/kit': 3.0.0
       consola: 2.15.3
       defu: 6.1.1
-      destr: 1.2.1
+      destr: 1.2.2
       detab: 3.0.2
       html-tags: 3.2.0
       json5: 2.2.1
       knitwork: 1.0.0
-      listhen: 1.0.0
+      listhen: 1.0.1
       mdast-util-to-hast: 12.2.4
       mdurl: 1.0.1
       ohash: 1.0.0
@@ -565,7 +583,7 @@ packages:
       rehype-sort-attributes: 4.0.0
       remark-emoji: 3.0.2
       remark-gfm: 3.0.1
-      remark-mdc: 1.1.1
+      remark-mdc: 1.1.3
       remark-parse: 10.0.1
       remark-rehype: 10.1.0
       remark-squeeze-paragraphs: 5.0.1
@@ -573,7 +591,7 @@ packages:
       shiki-es: 0.1.2
       slugify: 1.6.5
       socket.io-client: 4.5.4
-      ufo: 1.0.0
+      ufo: 1.0.1
       unified: 10.1.2
       unist-builder: 3.0.0
       unist-util-position: 4.0.3
@@ -652,7 +670,7 @@ packages:
       mlly: 1.0.0
       mri: 1.2.0
       pathe: 1.0.0
-      unbuild: 1.0.1
+      unbuild: 1.0.2
     transitivePeerDependencies:
       - sass
       - supports-color
@@ -753,7 +771,7 @@ packages:
     resolution: {integrity: sha512-jfpVHxi1AHfNO3D6iD1RJE6fx/7cAzekvG90poIzVawp/L+I4DNdy8pCgqBScJW4bfWOpHeLYbtQQlL/hPmkjw==}
     dev: true
 
-  /@nuxt/vite-builder/3.0.0_5akckbu4tmbn6phmzmqezegkrq:
+  /@nuxt/vite-builder/3.0.0_aldlgwvcjrslgpswsek6m4aziy:
     resolution: {integrity: sha512-eMnpPpjHU8rGZcsJUksCuSX+6dpId03q8LOSStsm6rXzrNJtZIcwt0nBRTUaigckXIozX8ZNl5u2OPGUfUbMrw==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     peerDependencies:
@@ -790,7 +808,7 @@ packages:
       unplugin: 1.0.0
       vite: 3.2.4
       vite-node: 0.25.3
-      vite-plugin-checker: 0.5.1_ijzhftcbnq5djhrq5avbc76z6m
+      vite-plugin-checker: 0.5.1_zgfdmaaqyawa5nodvg4qzc3sgi
       vue: 3.2.45
       vue-bundle-renderer: 1.0.0
     transitivePeerDependencies:
@@ -861,37 +879,37 @@ packages:
       - vti
     dev: true
 
-  /@nuxtjs/eslint-config-typescript/12.0.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@nuxtjs/eslint-config-typescript/12.0.0_f5jcydormhcqaoeadqwgqigppy:
     resolution: {integrity: sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      '@nuxtjs/eslint-config': 12.0.0_u2wpsm7b232uqhtq7f4wmetg54
-      '@typescript-eslint/eslint-plugin': 5.44.0_h2x4mqpqmrc3mjqbgwohavh3ii
-      '@typescript-eslint/parser': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
-      eslint: 8.29.0
-      eslint-import-resolver-typescript: 3.5.2_lt3hqehuojhfcbzgzqfngbtmrq
-      eslint-plugin-import: 2.26.0_u2wpsm7b232uqhtq7f4wmetg54
-      eslint-plugin-vue: 9.8.0_eslint@8.29.0
+      '@nuxtjs/eslint-config': 12.0.0_myy3v2f47smrltjpoyq5c36ab4
+      '@typescript-eslint/eslint-plugin': 5.44.0_jevmf2vlpxbyyhd3lmuw4ahrwa
+      '@typescript-eslint/parser': 5.44.0_f5jcydormhcqaoeadqwgqigppy
+      eslint: 8.30.0
+      eslint-import-resolver-typescript: 3.5.2_2lbwmhbr7bncddqbzzpg77o75m
+      eslint-plugin-import: 2.26.0_myy3v2f47smrltjpoyq5c36ab4
+      eslint-plugin-vue: 9.8.0_eslint@8.30.0
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
       - typescript
     dev: true
 
-  /@nuxtjs/eslint-config/12.0.0_u2wpsm7b232uqhtq7f4wmetg54:
+  /@nuxtjs/eslint-config/12.0.0_myy3v2f47smrltjpoyq5c36ab4:
     resolution: {integrity: sha512-ewenelo75x0eYEUK+9EBXjc/OopQCvdkmYmlZuoHq5kub/vtiRpyZ/autppwokpHUq8tiVyl2ejMakoiHiDTrg==}
     peerDependencies:
       eslint: ^8.23.0
     dependencies:
-      eslint: 8.29.0
-      eslint-config-standard: 17.0.0_jafpsg2texzosb7zvycotik6am
-      eslint-plugin-import: 2.26.0_u2wpsm7b232uqhtq7f4wmetg54
-      eslint-plugin-n: 15.5.1_eslint@8.29.0
-      eslint-plugin-node: 11.1.0_eslint@8.29.0
-      eslint-plugin-promise: 6.1.1_eslint@8.29.0
-      eslint-plugin-unicorn: 44.0.2_eslint@8.29.0
-      eslint-plugin-vue: 9.8.0_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-config-standard: 17.0.0_ufvcblwpbcepcckaz7he3smfie
+      eslint-plugin-import: 2.26.0_myy3v2f47smrltjpoyq5c36ab4
+      eslint-plugin-n: 15.5.1_eslint@8.30.0
+      eslint-plugin-node: 11.1.0_eslint@8.30.0
+      eslint-plugin-promise: 6.1.1_eslint@8.30.0
+      eslint-plugin-unicorn: 44.0.2_eslint@8.30.0
+      eslint-plugin-vue: 9.8.0_eslint@8.30.0
       local-pkg: 0.4.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -1056,7 +1074,7 @@ packages:
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-alias/4.0.2_rollup@3.5.0:
+  /@rollup/plugin-alias/4.0.2_rollup@3.7.4:
     resolution: {integrity: sha512-1hv7dBOZZwo3SEupxn4UA2N0EDThqSSS+wI1St1TNTBtOZvUchyIClyHcnDcjjrReTPZ47Faedrhblv4n+T5UQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1065,7 +1083,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.5.0
+      rollup: 3.7.4
       slash: 4.0.0
     dev: true
 
@@ -1087,7 +1105,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-commonjs/23.0.3_rollup@3.5.0:
+  /@rollup/plugin-commonjs/23.0.3_rollup@3.7.4:
     resolution: {integrity: sha512-31HxrT5emGfTyIfAs1lDQHj6EfYxTXcwtX5pIIhq+B/xZBNIqQ179d/CkYxlpYmFCxT78AeU4M8aL8Iv/IBxFA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1096,13 +1114,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.7.4
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.26.7
-      rollup: 3.5.0
+      rollup: 3.7.4
     dev: true
 
   /@rollup/plugin-inject/5.0.2_rollup@2.79.1:
@@ -1133,7 +1151,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-json/5.0.2_rollup@3.5.0:
+  /@rollup/plugin-json/5.0.2_rollup@3.7.4:
     resolution: {integrity: sha512-D1CoOT2wPvadWLhVcmpkDnesTzjhNIQRWLsc3fA49IFOP2Y84cFOOJ+nKGYedvXHKUsPeq07HR4hXpBBr+CHlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1142,8 +1160,8 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.5.0
-      rollup: 3.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.7.4
+      rollup: 3.7.4
     dev: true
 
   /@rollup/plugin-node-resolve/15.0.1_rollup@2.79.1:
@@ -1164,7 +1182,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-node-resolve/15.0.1_rollup@3.5.0:
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.7.4:
     resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1173,13 +1191,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.7.4
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.0
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 3.5.0
+      rollup: 3.7.4
     dev: true
 
   /@rollup/plugin-replace/5.0.1_rollup@2.79.1:
@@ -1196,7 +1214,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-replace/5.0.1_rollup@3.5.0:
+  /@rollup/plugin-replace/5.0.1_rollup@3.7.4:
     resolution: {integrity: sha512-Z3MfsJ4CK17BfGrZgvrcp/l6WXoKb0kokULO+zt/7bmcyayokDaQ2K3eDJcRLCTAlp5FPI4/gz9MHAsosz4Rag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1205,9 +1223,9 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.7.4
       magic-string: 0.26.7
-      rollup: 3.5.0
+      rollup: 3.7.4
     dev: true
 
   /@rollup/plugin-wasm/6.0.1_rollup@2.79.1:
@@ -1250,7 +1268,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/pluginutils/5.0.2_rollup@3.5.0:
+  /@rollup/pluginutils/5.0.2_rollup@3.7.4:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -1262,7 +1280,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.5.0
+      rollup: 3.7.4
     dev: true
 
   /@sindresorhus/is/5.3.0:
@@ -1362,7 +1380,7 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.44.0_h2x4mqpqmrc3mjqbgwohavh3ii:
+  /@typescript-eslint/eslint-plugin/5.44.0_jevmf2vlpxbyyhd3lmuw4ahrwa:
     resolution: {integrity: sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1373,12 +1391,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/parser': 5.44.0_f5jcydormhcqaoeadqwgqigppy
       '@typescript-eslint/scope-manager': 5.44.0
-      '@typescript-eslint/type-utils': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
-      '@typescript-eslint/utils': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/type-utils': 5.44.0_f5jcydormhcqaoeadqwgqigppy
+      '@typescript-eslint/utils': 5.44.0_f5jcydormhcqaoeadqwgqigppy
       debug: 4.3.4
-      eslint: 8.29.0
+      eslint: 8.30.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -1389,7 +1407,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.44.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/parser/5.44.0_f5jcydormhcqaoeadqwgqigppy:
     resolution: {integrity: sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1403,7 +1421,7 @@ packages:
       '@typescript-eslint/types': 5.44.0
       '@typescript-eslint/typescript-estree': 5.44.0_typescript@4.9.3
       debug: 4.3.4
-      eslint: 8.29.0
+      eslint: 8.30.0
       typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1417,7 +1435,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.44.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.44.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/type-utils/5.44.0_f5jcydormhcqaoeadqwgqigppy:
     resolution: {integrity: sha512-A1u0Yo5wZxkXPQ7/noGkRhV4J9opcymcr31XQtOzcc5nO/IHN2E2TPMECKWYpM3e6olWEM63fq/BaL1wEYnt/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1428,9 +1446,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.44.0_typescript@4.9.3
-      '@typescript-eslint/utils': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/utils': 5.44.0_f5jcydormhcqaoeadqwgqigppy
       debug: 4.3.4
-      eslint: 8.29.0
+      eslint: 8.30.0
       tsutils: 3.21.0_typescript@4.9.3
       typescript: 4.9.3
     transitivePeerDependencies:
@@ -1463,7 +1481,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.44.0_s5ps7njkmjlaqajutnox5ntcla:
+  /@typescript-eslint/utils/5.44.0_f5jcydormhcqaoeadqwgqigppy:
     resolution: {integrity: sha512-fMzA8LLQ189gaBjS0MZszw5HBdZgVwxVFShCO3QN+ws3GlPkcy9YuS3U4wkT6su0w+Byjq3mS3uamy9HE4Yfjw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1474,9 +1492,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.44.0
       '@typescript-eslint/types': 5.44.0
       '@typescript-eslint/typescript-estree': 5.44.0_typescript@4.9.3
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.29.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -1520,8 +1538,8 @@ packages:
       vue: 3.2.45
     dev: true
 
-  /@unocss/reset/0.46.5:
-    resolution: {integrity: sha512-DU1sisNixEaUsnfDdbU+POaedJLKUtalHnOOce2Txxrcakf7M2/I5/9cRIXt5diVbPjIyoDPcx+7Gn8K0cTGqg==}
+  /@unocss/reset/0.47.6:
+    resolution: {integrity: sha512-bdc2dbuDg+CzgeLowEwO1URRIMdzmCE4RH4IKpCpT1Xoa+92RRubdtzK4N/9ZiSo8d4vvfWcc8fvhZko/6smPQ==}
     dev: true
 
   /@vercel/nft/0.22.1:
@@ -1571,17 +1589,46 @@ packages:
       vue: 3.2.45
     dev: true
 
+  /@volar/language-core/1.0.13:
+    resolution: {integrity: sha512-aJhRiNjKFgLLB3nRJOfAeyle4StnEQgOKa0UpJU+k5EZd3QdiMfQmekXjxYeQj7NOZNQU7zCBEIvQ3gy15I7tA==}
+    dependencies:
+      '@volar/source-map': 1.0.13
+      '@vue/reactivity': 3.2.45
+      muggle-string: 0.1.0
+    dev: true
+
   /@volar/language-core/1.0.9:
     resolution: {integrity: sha512-5Fty3slLet6svXiJw2YxhYeo6c7wFdtILrql5bZymYLM+HbiZtJbryW1YnUEKAP7MO9Mbeh+TNH4Z0HFxHgIqw==}
     dependencies:
       '@volar/source-map': 1.0.9
       '@vue/reactivity': 3.2.45
       muggle-string: 0.1.0
+    dev: false
+
+  /@volar/source-map/1.0.13:
+    resolution: {integrity: sha512-dU0plR9BS+bLs7u4chWay+VEIFTrLF15rG2634lGcu7o+z01bRO1U2cegZuIPy46SNkN3ONErLHwS09NBM+Ucg==}
+    dependencies:
+      muggle-string: 0.1.0
+    dev: true
 
   /@volar/source-map/1.0.9:
     resolution: {integrity: sha512-fazB/vy5ZEJ3yKx4fabJyGNI3CBkdLkfEIRVu6+1P3VixK0Mn+eqyUIkLBrzGYaeFM3GybhCLCvsVdNz0Fu/CQ==}
     dependencies:
       muggle-string: 0.1.0
+    dev: false
+
+  /@volar/vue-language-core/1.0.13:
+    resolution: {integrity: sha512-DRUg7yk4w2+5XFk8LS1dbXEM0na2uAddOj3KWHROPQmn78pfgXEH3r0NGDCnxElWJX5Y16iameisOjtOhevxog==}
+    dependencies:
+      '@volar/language-core': 1.0.13
+      '@volar/source-map': 1.0.13
+      '@vue/compiler-dom': 3.2.45
+      '@vue/compiler-sfc': 3.2.45
+      '@vue/reactivity': 3.2.45
+      '@vue/shared': 3.2.45
+      minimatch: 5.1.0
+      vue-template-compiler: 2.7.14
+    dev: true
 
   /@volar/vue-language-core/1.0.9:
     resolution: {integrity: sha512-tofNoR8ShPFenHT1YVMuvoXtXWwoQE+fiXVqSmW0dSKZqEDjWQ3YeXSd0a6aqyKaIbvR7kWWGp34WbpQlwf9Ww==}
@@ -1594,6 +1641,7 @@ packages:
       '@vue/shared': 3.2.45
       minimatch: 5.1.0
       vue-template-compiler: 2.7.14
+    dev: false
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
@@ -1893,6 +1941,15 @@ packages:
       is-string: 1.0.7
     dev: true
 
+  /assert/2.0.0:
+    resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
+    dependencies:
+      es6-object-assign: 1.1.0
+      is-nan: 1.3.2
+      object-is: 1.1.5
+      util: 0.12.5
+    dev: true
+
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
@@ -1946,6 +2003,11 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.19
       postcss-value-parser: 4.2.0
+    dev: true
+
+  /available-typed-arrays/1.0.5:
+    resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /bail/2.0.2:
@@ -2768,6 +2830,10 @@ packages:
   /destr/1.2.1:
     resolution: {integrity: sha512-ud8w0qMLlci6iFG7CNgeRr8OcbUWMsbfjtWft1eJ5Luqrz/M8Ebqk/KCzne8rKUlIQWWfLv0wD6QHrqOf4GshA==}
 
+  /destr/1.2.2:
+    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
+    dev: true
+
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -3010,8 +3076,21 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /es6-object-assign/1.1.0:
+    resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
+    dev: true
+
   /esbuild-android-64/0.15.16:
     resolution: {integrity: sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-64/0.15.18:
+    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -3028,8 +3107,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-arm64/0.15.18:
+    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-64/0.15.16:
     resolution: {integrity: sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.15.18:
+    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3046,8 +3143,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-arm64/0.15.18:
+    resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-64/0.15.16:
     resolution: {integrity: sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.15.18:
+    resolution: {integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3064,8 +3179,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-arm64/0.15.18:
+    resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-32/0.15.16:
     resolution: {integrity: sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.15.18:
+    resolution: {integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -3082,8 +3215,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-64/0.15.18:
+    resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm/0.15.16:
     resolution: {integrity: sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.15.18:
+    resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3100,8 +3251,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm64/0.15.18:
+    resolution: {integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-mips64le/0.15.16:
     resolution: {integrity: sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.15.18:
+    resolution: {integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -3118,8 +3287,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-ppc64le/0.15.18:
+    resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-riscv64/0.15.16:
     resolution: {integrity: sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.15.18:
+    resolution: {integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -3136,8 +3323,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-s390x/0.15.18:
+    resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-netbsd-64/0.15.16:
     resolution: {integrity: sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.15.18:
+    resolution: {integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3154,8 +3359,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-openbsd-64/0.15.18:
+    resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-sunos-64/0.15.16:
     resolution: {integrity: sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.15.18:
+    resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3172,6 +3395,15 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-32/0.15.18:
+    resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-64/0.15.16:
     resolution: {integrity: sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==}
     engines: {node: '>=12'}
@@ -3181,8 +3413,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.15.18:
+    resolution: {integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.15.16:
     resolution: {integrity: sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.18:
+    resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3218,6 +3468,36 @@ packages:
       esbuild-windows-32: 0.15.16
       esbuild-windows-64: 0.15.16
       esbuild-windows-arm64: 0.15.16
+    dev: true
+
+  /esbuild/0.15.18:
+    resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.18
+      '@esbuild/linux-loong64': 0.15.18
+      esbuild-android-64: 0.15.18
+      esbuild-android-arm64: 0.15.18
+      esbuild-darwin-64: 0.15.18
+      esbuild-darwin-arm64: 0.15.18
+      esbuild-freebsd-64: 0.15.18
+      esbuild-freebsd-arm64: 0.15.18
+      esbuild-linux-32: 0.15.18
+      esbuild-linux-64: 0.15.18
+      esbuild-linux-arm: 0.15.18
+      esbuild-linux-arm64: 0.15.18
+      esbuild-linux-mips64le: 0.15.18
+      esbuild-linux-ppc64le: 0.15.18
+      esbuild-linux-riscv64: 0.15.18
+      esbuild-linux-s390x: 0.15.18
+      esbuild-netbsd-64: 0.15.18
+      esbuild-openbsd-64: 0.15.18
+      esbuild-sunos-64: 0.15.18
+      esbuild-windows-32: 0.15.18
+      esbuild-windows-64: 0.15.18
+      esbuild-windows-arm64: 0.15.18
     dev: true
 
   /escalade/3.1.1:
@@ -3259,7 +3539,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-standard/17.0.0_jafpsg2texzosb7zvycotik6am:
+  /eslint-config-standard/17.0.0_ufvcblwpbcepcckaz7he3smfie:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1
@@ -3267,10 +3547,10 @@ packages:
       eslint-plugin-n: ^15.0.0
       eslint-plugin-promise: ^6.0.0
     dependencies:
-      eslint: 8.29.0
-      eslint-plugin-import: 2.26.0_u2wpsm7b232uqhtq7f4wmetg54
-      eslint-plugin-n: 15.5.1_eslint@8.29.0
-      eslint-plugin-promise: 6.1.1_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-plugin-import: 2.26.0_myy3v2f47smrltjpoyq5c36ab4
+      eslint-plugin-n: 15.5.1_eslint@8.30.0
+      eslint-plugin-promise: 6.1.1_eslint@8.30.0
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -3282,7 +3562,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.2_lt3hqehuojhfcbzgzqfngbtmrq:
+  /eslint-import-resolver-typescript/3.5.2_2lbwmhbr7bncddqbzzpg77o75m:
     resolution: {integrity: sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -3291,8 +3571,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
-      eslint: 8.29.0
-      eslint-plugin-import: 2.26.0_u2wpsm7b232uqhtq7f4wmetg54
+      eslint: 8.30.0
+      eslint-plugin-import: 2.26.0_myy3v2f47smrltjpoyq5c36ab4
       get-tsconfig: 4.2.0
       globby: 13.1.2
       is-core-module: 2.11.0
@@ -3302,7 +3582,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.4_hankzu7y7wumak4qaw43nohl4e:
+  /eslint-module-utils/2.7.4_4akmunq3ssxbyn6al3qo2cb3iu:
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3323,38 +3603,38 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/parser': 5.44.0_f5jcydormhcqaoeadqwgqigppy
       debug: 3.2.7
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.2_lt3hqehuojhfcbzgzqfngbtmrq
+      eslint-import-resolver-typescript: 3.5.2_2lbwmhbr7bncddqbzzpg77o75m
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-es/3.0.1_eslint@8.29.0:
+  /eslint-plugin-es/3.0.1_eslint@8.30.0:
     resolution: {integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-es/4.1.0_eslint@8.29.0:
+  /eslint-plugin-es/4.1.0_eslint@8.30.0:
     resolution: {integrity: sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=4.19.1'
     dependencies:
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-utils: 2.1.0
       regexpp: 3.2.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_u2wpsm7b232uqhtq7f4wmetg54:
+  /eslint-plugin-import/2.26.0_myy3v2f47smrltjpoyq5c36ab4:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -3364,14 +3644,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.44.0_s5ps7njkmjlaqajutnox5ntcla
+      '@typescript-eslint/parser': 5.44.0_f5jcydormhcqaoeadqwgqigppy
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_hankzu7y7wumak4qaw43nohl4e
+      eslint-module-utils: 2.7.4_4akmunq3ssxbyn6al3qo2cb3iu
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -3385,16 +3665,16 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-n/15.5.1_eslint@8.29.0:
+  /eslint-plugin-n/15.5.1_eslint@8.30.0:
     resolution: {integrity: sha512-kAd+xhZm7brHoFLzKLB7/FGRFJNg/srmv67mqb7tto22rpr4wv/LV6RuXzAfv3jbab7+k1wi42PsIhGviywaaw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
       builtins: 5.0.1
-      eslint: 8.29.0
-      eslint-plugin-es: 4.1.0_eslint@8.29.0
-      eslint-utils: 3.0.0_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-plugin-es: 4.1.0_eslint@8.30.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       ignore: 5.2.0
       is-core-module: 2.11.0
       minimatch: 3.1.2
@@ -3402,14 +3682,14 @@ packages:
       semver: 7.3.8
     dev: true
 
-  /eslint-plugin-node/11.1.0_eslint@8.29.0:
+  /eslint-plugin-node/11.1.0_eslint@8.30.0:
     resolution: {integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>=5.16.0'
     dependencies:
-      eslint: 8.29.0
-      eslint-plugin-es: 3.0.1_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-plugin-es: 3.0.1_eslint@8.30.0
       eslint-utils: 2.1.0
       ignore: 5.2.0
       minimatch: 3.1.2
@@ -3417,16 +3697,16 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-promise/6.1.1_eslint@8.29.0:
+  /eslint-plugin-promise/6.1.1_eslint@8.30.0:
     resolution: {integrity: sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.29.0
+      eslint: 8.30.0
     dev: true
 
-  /eslint-plugin-unicorn/44.0.2_eslint@8.29.0:
+  /eslint-plugin-unicorn/44.0.2_eslint@8.30.0:
     resolution: {integrity: sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==}
     engines: {node: '>=14.18'}
     peerDependencies:
@@ -3435,8 +3715,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       ci-info: 3.7.0
       clean-regexp: 1.0.0
-      eslint: 8.29.0
-      eslint-utils: 3.0.0_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       esquery: 1.4.0
       indent-string: 4.0.0
       is-builtin-module: 3.2.0
@@ -3449,19 +3729,19 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vue/9.8.0_eslint@8.29.0:
+  /eslint-plugin-vue/9.8.0_eslint@8.30.0:
     resolution: {integrity: sha512-E/AXwcTzunyzM83C2QqDHxepMzvI2y6x+mmeYHbVDQlKFqmKYvRrhaVixEeeG27uI44p9oKDFiyCRw4XxgtfHA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      eslint: 8.29.0
-      eslint-utils: 3.0.0_eslint@8.29.0
+      eslint: 8.30.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.11
       semver: 7.3.8
-      vue-eslint-parser: 9.1.0_eslint@8.29.0
+      vue-eslint-parser: 9.1.0_eslint@8.30.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -3490,13 +3770,13 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.29.0:
+  /eslint-utils/3.0.0_eslint@8.30.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -3515,13 +3795,13 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.29.0:
-    resolution: {integrity: sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==}
+  /eslint/8.30.0:
+    resolution: {integrity: sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint/eslintrc': 1.3.3
-      '@humanwhocodes/config-array': 0.11.7
+      '@eslint/eslintrc': 1.4.0
+      '@humanwhocodes/config-array': 0.11.8
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -3531,7 +3811,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.29.0
+      eslint-utils: 3.0.0_eslint@8.30.0
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
       esquery: 1.4.0
@@ -3540,7 +3820,7 @@ packages:
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.18.0
+      globals: 13.19.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       import-fresh: 3.3.0
@@ -3783,6 +4063,12 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
+
+  /for-each/0.3.3:
+    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+    dependencies:
+      is-callable: 1.2.7
     dev: true
 
   /form-data-encoder/2.1.4:
@@ -4038,8 +4324,8 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals/13.18.0:
-    resolution: {integrity: sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==}
+  /globals/13.19.0:
+    resolution: {integrity: sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -4073,6 +4359,12 @@ packages:
 
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: true
+
+  /gopd/1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+    dependencies:
+      get-intrinsic: 1.1.3
     dev: true
 
   /got/12.5.3:
@@ -4590,6 +4882,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-generator-function/1.0.10:
+    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
+
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -4619,6 +4918,14 @@ packages:
 
   /is-module/1.0.0:
     resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
+  /is-nan/1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
     dev: true
 
   /is-negative-zero/2.0.2:
@@ -4723,6 +5030,17 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
+
+  /is-typed-array/1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-typedarray/1.0.0:
@@ -4926,6 +5244,19 @@ packages:
       ufo: 1.0.0
     dev: true
 
+  /listhen/1.0.1:
+    resolution: {integrity: sha512-RBzBGHMCc5wP8J5Vf8WgF4CAJH8dWHi9LaKB7vfzZt54CiH/0dp01rudy2hFD9wCrTM+UfxFVnn5wTIiY+Qhiw==}
+    dependencies:
+      clipboardy: 3.0.0
+      colorette: 2.0.19
+      defu: 6.1.1
+      get-port-please: 2.6.1
+      http-shutdown: 1.2.2
+      ip-regex: 5.0.0
+      node-forge: 1.3.1
+      ufo: 1.0.1
+    dev: true
+
   /local-pkg/0.4.2:
     resolution: {integrity: sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==}
     engines: {node: '>=14'}
@@ -5062,6 +5393,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -5613,7 +5951,7 @@ packages:
         optional: true
     dependencies:
       defu: 6.1.1
-      esbuild: 0.15.16
+      esbuild: 0.15.18
       fs-extra: 10.1.0
       globby: 13.1.2
       jiti: 1.16.0
@@ -5956,7 +6294,7 @@ packages:
       - vti
     dev: true
 
-  /nuxt/3.0.0_s5ps7njkmjlaqajutnox5ntcla:
+  /nuxt/3.0.0_f5jcydormhcqaoeadqwgqigppy:
     resolution: {integrity: sha512-RNlD78uv04ZiXWmlx9f1tnJfrqsYAWHU+4gbgOTQpIBmQzHWPWiox+fm/1m93iKfEd5sJi9TJUoXX5yBObVZYw==}
     engines: {node: ^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0}
     hasBin: true
@@ -5966,7 +6304,7 @@ packages:
       '@nuxt/schema': 3.0.0
       '@nuxt/telemetry': 2.1.8
       '@nuxt/ui-templates': 1.0.0
-      '@nuxt/vite-builder': 3.0.0_5akckbu4tmbn6phmzmqezegkrq
+      '@nuxt/vite-builder': 3.0.0_aldlgwvcjrslgpswsek6m4aziy
       '@unhead/ssr': 1.0.4
       '@vue/reactivity': 3.2.45
       '@vue/shared': 3.2.45
@@ -6031,6 +6369,14 @@ packages:
 
   /object-inspect/1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
+    dev: true
+
+  /object-is/1.1.5:
+    resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
     dev: true
 
   /object-keys/1.1.1:
@@ -6375,26 +6721,27 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /pinceau/0.7.2:
-    resolution: {integrity: sha512-TML8eIhovXOD3mSA3N/X/HvSbnwljJgWRLTYGeE7I3oI3gDAQhwHpUENfklik7dmOZJrksyaMv+ssZFl+/ciow==}
+  /pinceau/0.8.9:
+    resolution: {integrity: sha512-5iUN4FuLUK2oyP0a7vMYJooyXlF8DutrSbWuBqp0FrVqcDI9j5WG+RZUY57uFkUICcSXmoghQ3nJZ/Dxnr77nA==}
     dependencies:
-      '@unocss/reset': 0.46.5
-      '@volar/vue-language-core': 1.0.9
+      '@unocss/reset': 0.47.6
+      '@volar/vue-language-core': 1.0.13
+      acorn: 8.8.1
       chroma-js: 2.4.2
       consola: 2.15.3
       csstype: 3.1.1
       defu: 6.1.1
-      magic-string: 0.26.7
+      magic-string: 0.27.0
       nanoid: 4.0.0
       ohash: 1.0.0
-      postcss-custom-properties: 12.1.10
+      postcss-custom-properties: 12.1.11
       postcss-dark-theme-class: 0.7.3
       postcss-nested: 6.0.0
-      recast: 0.21.5
+      recast: 0.22.0
       scule: 1.0.0
       style-dictionary-esm: 1.0.15
-      unbuild: 1.0.1
-      unplugin: 1.0.0
+      unbuild: 1.0.2
+      unplugin: 1.0.1
     transitivePeerDependencies:
       - postcss
       - sass
@@ -6456,8 +6803,8 @@ packages:
       postcss-value-parser: 4.2.0
     dev: true
 
-  /postcss-custom-properties/12.1.10:
-    resolution: {integrity: sha512-U3BHdgrYhCrwTVcByFHs9EOBoqcKq4Lf3kXwbTi4hhq0qWhl/pDWq2THbv/ICX/Fl9KqeHBb8OVrTf2OaYF07A==}
+  /postcss-custom-properties/12.1.11:
+    resolution: {integrity: sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==}
     engines: {node: ^12 || ^14 || >=16}
     peerDependencies:
       postcss: ^8.2
@@ -7059,10 +7406,11 @@ packages:
     dependencies:
       picomatch: 2.3.1
 
-  /recast/0.21.5:
-    resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
+  /recast/0.22.0:
+    resolution: {integrity: sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==}
     engines: {node: '>= 4'}
     dependencies:
+      assert: 2.0.0
       ast-types: 0.15.2
       esprima: 4.0.1
       source-map: 0.6.1
@@ -7247,6 +7595,27 @@ packages:
       - supports-color
     dev: true
 
+  /remark-mdc/1.1.3:
+    resolution: {integrity: sha512-ilYSkkQJhu5cUCEE2CJEncoMDoarP32ugfJpFWghXbnv3sWI3j2HtJuArc9tZzxN4ID6fngio3d8N87QfQAnRQ==}
+    dependencies:
+      flat: 5.0.2
+      js-yaml: 4.1.0
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+      micromark: 3.1.0
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-factory-whitespace: 1.0.0
+      micromark-util-character: 1.1.0
+      parse-entities: 4.0.0
+      scule: 1.0.0
+      stringify-entities: 4.0.3
+      unist-util-visit: 4.1.1
+      unist-util-visit-parents: 5.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /remark-parse/10.0.1:
     resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
     dependencies:
@@ -7337,7 +7706,7 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-dts/5.0.0_thigodkhmbmbgju2inwjpgoskq:
+  /rollup-plugin-dts/5.0.0_6ro6gq72rszfdmymkp46l2rwkq:
     resolution: {integrity: sha512-OO8ayCvuJCKaQSShyVTARxGurVVk4ulzbuvz+0zFd1f93vlnWFU5pBMT7HFeS6uj7MvvZLx4kUAarGATSU1+Ng==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -7345,7 +7714,7 @@ packages:
       typescript: ^4.1
     dependencies:
       magic-string: 0.26.7
-      rollup: 3.5.0
+      rollup: 3.7.4
       typescript: 4.9.3
     optionalDependencies:
       '@babel/code-frame': 7.18.6
@@ -7393,8 +7762,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /rollup/3.5.0:
-    resolution: {integrity: sha512-TYu2L+TGhmNsXCtByont89u+ATQLcDy6A+++PwLXYunRtOm7XnaD+65s1pvewaOxMYR0eOkMXn9/i0saBxxpnQ==}
+  /rollup/3.7.4:
+    resolution: {integrity: sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8141,6 +8510,10 @@ packages:
   /ufo/1.0.0:
     resolution: {integrity: sha512-DRty0ZBNlJ2R59y4mEupJRKLbkLQsc4qtxjpQv78AwEDuBkaUogMc2LkeqW3HddFlw6NwnXYfdThEZOiNgkmmQ==}
 
+  /ufo/1.0.1:
+    resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}
+    dev: true
+
   /ultrahtml/1.0.3:
     resolution: {integrity: sha512-QpTl78vv2o004UPD6b+Vjfoh2b33PV0LS6UHoI1u3wQ2xVRJAkW8Ip4QBiL6JTlMMtIWOXqli98WnsWx6IFFRg==}
     dev: true
@@ -8154,24 +8527,24 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /unbuild/1.0.1:
-    resolution: {integrity: sha512-i2mkbLNFZDJJdpsbg4JflHldKeF3J0K+mLGUdh8jrHBSTHZBw8qFWI7t/AUrGjHxa/O/vkIod65LXu9ktPiUHw==}
+  /unbuild/1.0.2:
+    resolution: {integrity: sha512-nQ2rxQ9aqIPzVhOEs6T/YcDGb6PWf6BAtQ0as+YWoaWCfezAdeL3KlNWSh279D6euOeCt94t0b/vAGr3GKu9Gw==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 4.0.2_rollup@3.5.0
-      '@rollup/plugin-commonjs': 23.0.3_rollup@3.5.0
-      '@rollup/plugin-json': 5.0.2_rollup@3.5.0
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.5.0
-      '@rollup/plugin-replace': 5.0.1_rollup@3.5.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.5.0
+      '@rollup/plugin-alias': 4.0.2_rollup@3.7.4
+      '@rollup/plugin-commonjs': 23.0.3_rollup@3.7.4
+      '@rollup/plugin-json': 5.0.2_rollup@3.7.4
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.7.4
+      '@rollup/plugin-replace': 5.0.1_rollup@3.7.4
+      '@rollup/pluginutils': 5.0.2_rollup@3.7.4
       chalk: 5.1.2
       consola: 2.15.3
       defu: 6.1.1
-      esbuild: 0.15.16
+      esbuild: 0.15.18
       globby: 13.1.2
       hookable: 5.4.2
       jiti: 1.16.0
-      magic-string: 0.26.7
+      magic-string: 0.27.0
       mkdirp: 1.0.4
       mkdist: 1.0.0_typescript@4.9.3
       mlly: 1.0.0
@@ -8180,8 +8553,8 @@ packages:
       pkg-types: 1.0.1
       pretty-bytes: 6.0.0
       rimraf: 3.0.2
-      rollup: 3.5.0
-      rollup-plugin-dts: 5.0.0_thigodkhmbmbgju2inwjpgoskq
+      rollup: 3.7.4
+      rollup-plugin-dts: 5.0.0_6ro6gq72rszfdmymkp46l2rwkq
       scule: 1.0.0
       typescript: 4.9.3
       untyped: 1.0.0
@@ -8352,6 +8725,15 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.6
 
+  /unplugin/1.0.1:
+    resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
+    dependencies:
+      acorn: 8.8.1
+      chokidar: 3.5.3
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.5.0
+    dev: true
+
   /unstorage/1.0.1:
     resolution: {integrity: sha512-J1c4b8K2KeihHrQtdgl/ybIapArUbPaPb+TyJy/nGSauDwDYqciZsEKdkee568P3c8SSH4TIgnGRHDWMPGw+Lg==}
     dependencies:
@@ -8438,6 +8820,16 @@ packages:
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  /util/0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.1.1
+      is-generator-function: 1.0.10
+      is-typed-array: 1.1.10
+      which-typed-array: 1.1.9
+    dev: true
+
   /uvu/0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
@@ -8500,45 +8892,6 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker/0.5.1_ijzhftcbnq5djhrq5avbc76z6m:
-    resolution: {integrity: sha512-NFiO1PyK9yGuaeSnJ7Whw9fnxLc1AlELnZoyFURnauBYhbIkx9n+PmIXxSFUuC9iFyACtbJQUAEuQi6yHs2Adg==}
-    engines: {node: '>=14.16'}
-    peerDependencies:
-      eslint: '>=7'
-      typescript: '*'
-      vite: ^2.0.0 || ^3.0.0-0
-      vls: '*'
-      vti: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      typescript:
-        optional: true
-      vls:
-        optional: true
-      vti:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      commander: 8.3.0
-      eslint: 8.29.0
-      fast-glob: 3.2.12
-      lodash.debounce: 4.0.8
-      lodash.pick: 4.4.0
-      npm-run-path: 4.0.1
-      strip-ansi: 6.0.1
-      tiny-invariant: 1.3.1
-      typescript: 4.9.3
-      vite: 3.2.4
-      vscode-languageclient: 7.0.0
-      vscode-languageserver: 7.0.0
-      vscode-languageserver-textdocument: 1.0.7
-      vscode-uri: 3.0.6
-    dev: true
-
   /vite-plugin-checker/0.5.1_vite@3.2.4:
     resolution: {integrity: sha512-NFiO1PyK9yGuaeSnJ7Whw9fnxLc1AlELnZoyFURnauBYhbIkx9n+PmIXxSFUuC9iFyACtbJQUAEuQi6yHs2Adg==}
     engines: {node: '>=14.16'}
@@ -8569,6 +8922,45 @@ packages:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
+      vite: 3.2.4
+      vscode-languageclient: 7.0.0
+      vscode-languageserver: 7.0.0
+      vscode-languageserver-textdocument: 1.0.7
+      vscode-uri: 3.0.6
+    dev: true
+
+  /vite-plugin-checker/0.5.1_zgfdmaaqyawa5nodvg4qzc3sgi:
+    resolution: {integrity: sha512-NFiO1PyK9yGuaeSnJ7Whw9fnxLc1AlELnZoyFURnauBYhbIkx9n+PmIXxSFUuC9iFyACtbJQUAEuQi6yHs2Adg==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      eslint: '>=7'
+      typescript: '*'
+      vite: ^2.0.0 || ^3.0.0-0
+      vls: '*'
+      vti: '*'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      typescript:
+        optional: true
+      vls:
+        optional: true
+      vti:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      commander: 8.3.0
+      eslint: 8.30.0
+      fast-glob: 3.2.12
+      lodash.debounce: 4.0.8
+      lodash.pick: 4.4.0
+      npm-run-path: 4.0.1
+      strip-ansi: 6.0.1
+      tiny-invariant: 1.3.1
+      typescript: 4.9.3
       vite: 3.2.4
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
@@ -8758,14 +9150,14 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
-  /vue-eslint-parser/9.1.0_eslint@8.29.0:
+  /vue-eslint-parser/9.1.0_eslint@8.30.0:
     resolution: {integrity: sha512-NGn/iQy8/Wb7RrRa4aRkokyCZfOUWk19OP5HP6JEozQFX5AoS/t+Z0ZN7FY4LlmWc4FNI922V7cvX28zctN8dQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.29.0
+      eslint: 8.30.0
       eslint-scope: 7.1.1
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
@@ -8827,6 +9219,10 @@ packages:
   /webpack-virtual-modules/0.4.6:
     resolution: {integrity: sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==}
 
+  /webpack-virtual-modules/0.5.0:
+    resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
+    dev: true
+
   /whatwg-url/5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
@@ -8842,6 +9238,18 @@ packages:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
+    dev: true
+
+  /which-typed-array/1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
     dev: true
 
   /which/2.0.2:

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,7 +53,7 @@ export default defineNuxtModule<ModuleOptions>({
       schema: {}
     }
   }),
-  async setup(options, nuxt) {
+  async setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
 
     let parser: ComponentMetaParser

--- a/src/module.ts
+++ b/src/module.ts
@@ -50,7 +50,16 @@ export default defineNuxtModule<ModuleOptions>({
     ],
     checkerOptions: {
       forceUseTs: true,
-      schema: {}
+      schema: {
+        ignore: [
+          'NuxtComponentMetaNames', // avoid loop
+          'RouteLocationRaw', // vue router
+          'RouteLocationPathRaw', // vue router
+          'RouteLocationNamedRaw', // vue router
+          'ComputedStyleProp', // Pinceau
+          'VariantProp' // Pinceau
+        ]
+      }
     }
   }),
   async setup (options, nuxt) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import {
   addServerHandler,
   createResolver,
@@ -12,6 +12,7 @@ import type { ComponentsDir } from '@nuxt/schema'
 import { withoutLeadingSlash } from 'ufo'
 import { metaPlugin } from './unplugin'
 import { ModuleOptions } from './options'
+import { ComponentMetaParser, useComponentMetaParser } from './parser'
 
 export * from './options'
 
@@ -26,6 +27,7 @@ export default defineNuxtModule<ModuleOptions>({
     componentDirs: [],
     components: [],
     silent: true,
+    exclude: ['nuxt/dist/app/components/client-only', 'nuxt/dist/app/components/dev-only'],
     transformers: [
       // Normalize
       (component, code) => {
@@ -51,10 +53,11 @@ export default defineNuxtModule<ModuleOptions>({
       schema: {}
     }
   }),
-  async setup (options, nuxt) {
-    // Regex to match colors.primary.100 in {colors.primary.100}
-
+  async setup(options, nuxt) {
     const resolver = createResolver(import.meta.url)
+
+    let parser: ComponentMetaParser
+    let parserReady: Promise<void>
 
     // Retrieve transformers
     let transformers = options?.transformers || []
@@ -75,6 +78,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.hook('components:extend', (_components) => {
       components = _components
       options.components = components
+
+      // Create parser after components has been resolved
+      parser = useComponentMetaParser({ ...options, componentDirs, components } as Required<ModuleOptions>)
     })
 
     // Add useComponentMeta
@@ -99,9 +105,10 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Vite plugin
-    nuxt.hook('vite:extend', (vite: any) => {
+    nuxt.hook('vite:extend', async (vite: any) => {
+      await parser.updateOutput()
       vite.config.plugins = vite.config.plugins || []
-      vite.config.plugins.push(metaPlugin.vite(options as Required<ModuleOptions>))
+      vite.config.plugins.push(metaPlugin.vite({ parser }))
     })
 
     // Inject output alias

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,9 +5,10 @@ import { HookData } from './types'
 export interface ModuleOptions {
   outputDir?: string
   rootDir?: string
-  silent?: boolean
+  debug?: boolean | 2
   componentDirs: (string | ComponentsDir)[]
   components?: ComponentsOptions[]
+  exclude?: string[]
   checkerOptions?: MetaCheckerOptions
   transformers?: ((component: any, code: string) => ({ component: any; code: string }))[]
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,179 @@
+import {
+  resolveModule,
+} from '@nuxt/kit'
+import { join } from 'pathe'
+import fsp from 'fs/promises'
+import { createComponentMetaCheckerByJsonConfig } from 'vue-component-meta'
+import { performance } from 'perf_hooks'
+import type { ModuleOptions } from './options'
+import consola from 'consola'
+
+export function useComponentMetaParser(
+  {
+    outputDir = join(process.cwd(), '.component-meta/'),
+    rootDir = process.cwd(),
+    components: _components = [],
+    componentDirs = [],
+    checkerOptions,
+    exclude = [],
+    transformers = [],
+    debug = false
+  }: ModuleOptions
+) {
+  const logger = consola.withScope('nuxt-component-meta')
+
+  const outputPath = join(outputDir, 'component-meta')
+
+  /**
+   * Initialize component data object from components
+   */
+  const components = {
+    ...(_components || []).reduce(
+      (acc: any, component: any) => {
+        // Locally support exclude as it seem broken from createComponentMetaCheckerByJsonConfig
+        if (exclude.find((excludePath) => component.filePath.includes(excludePath))) { return acc }
+
+        if (!component.filePath || !component.pascalName) { return acc }
+
+        const filePath = resolveModule(component.filePath, { paths: [rootDir] })
+
+        acc[component.pascalName] = {
+          ...component,
+          fullPath: filePath,
+          filePath: filePath.replace(rootDir, ''),
+          meta: {
+            props: [],
+            slots: [],
+            events: [],
+            exposed: []
+          }
+        }
+
+        return acc
+      },
+      {}
+    )
+  }
+
+  const getComponents = () => components
+
+  const getStringifiedComponents = () => JSON.stringify(getComponents(), null, 2)
+
+  const getVirtualModuleContent = () => `export default ${getStringifiedComponents()}`
+
+  const checker = createComponentMetaCheckerByJsonConfig(
+    rootDir,
+    {
+      extends: `${rootDir}/tsconfig.json`,
+      skipLibCheck: true,
+      include: [
+        '**/*',
+        ...componentDirs.map(dir => `${typeof dir === 'string' ? dir : (dir?.path || '')}/**/*`)
+      ],
+      exclude
+    },
+    checkerOptions
+  )
+
+  /**
+   * Output is needed for Nitro
+   */
+  const updateOutput = async () => {
+    // Main export of component data
+    await fsp.writeFile(
+      outputPath + '.mjs',
+      getVirtualModuleContent(),
+      'utf-8'
+    )
+  }
+
+  const fetchComponent = async (component: string | any) => {
+    const startTime = performance.now()
+    try {
+      if (typeof component === 'string') {
+        if (components[component]) {
+          component = components[component]
+        } else {
+          component = Object.entries(components).find(([, comp]: any) => (comp.fullPath === component))
+
+          // No component found via string
+          if (!component) { return }
+
+          component = component[1]
+        }
+      }
+
+      // Component is missing required values
+      if (!component?.fullPath || !component?.pascalName) { return }
+
+      // Read component code
+      let code = await fsp.readFile(component.fullPath, 'utf-8')
+
+      // Support transformers
+      if (transformers && transformers.length > 0) {
+        for (const transform of transformers) {
+          const transformResult = transform(component, code)
+          component = transformResult?.component || component
+          code = transformResult?.code || code
+        }
+      }
+
+      // Ensure file is updated
+      checker.updateFile(component.fullPath, code)
+
+      const { props, slots, events, exposed } = checker.getComponentMeta(component.fullPath)
+
+      component.meta.slots = slots
+      component.meta.events = events
+      component.meta.exposed = exposed
+      component.meta.props = props
+        .filter(prop => !prop.global)
+        .sort((a, b) => {
+          // sort required properties first
+          if (!a.required && b.required) {
+            return 1
+          }
+          if (a.required && !b.required) {
+            return -1
+          }
+          // then ensure boolean properties are sorted last
+          if (a.type === 'boolean' && b.type !== 'boolean') {
+            return 1
+          }
+          if (a.type !== 'boolean' && b.type === 'boolean') {
+            return -1
+          }
+
+          return 0
+        })
+
+      components[component.pascalName] = component
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      !debug && logger.info(`Could not parse ${component?.pascalName || component?.filePath || 'a component'}!`)
+    }
+    const endTime = performance.now()
+    if (debug === 2) logger.success(`${component?.pascalName || component?.filePath || 'a component'} metas parsed in ${(endTime - startTime).toFixed(2)}ms`)
+  }
+
+  const fetchComponents = async () => {
+    const startTime = performance.now()
+    await Promise.all(Object.values(components).map(fetchComponent))
+    const endTime = performance.now()
+    if (!debug) logger.success(`Components metas parsed in ${(endTime - startTime).toFixed(2)}ms`)
+  }
+
+  return {
+    checker,
+    outputPath,
+    updateOutput,
+    fetchComponent,
+    fetchComponents,
+    getComponents,
+    components,
+    getStringifiedComponents,
+    getVirtualModuleContent
+  }
+}
+
+export type ComponentMetaParser = ReturnType<typeof useComponentMetaParser>

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,14 +1,14 @@
+import fsp from 'fs/promises'
+import { performance } from 'perf_hooks'
 import {
-  resolveModule,
+  resolveModule
 } from '@nuxt/kit'
 import { join } from 'pathe'
-import fsp from 'fs/promises'
 import { createComponentMetaCheckerByJsonConfig } from 'vue-component-meta'
-import { performance } from 'perf_hooks'
-import type { ModuleOptions } from './options'
 import consola from 'consola'
+import type { ModuleOptions } from './options'
 
-export function useComponentMetaParser(
+export function useComponentMetaParser (
   {
     outputDir = join(process.cwd(), '.component-meta/'),
     rootDir = process.cwd(),
@@ -31,7 +31,7 @@ export function useComponentMetaParser(
     ...(_components || []).reduce(
       (acc: any, component: any) => {
         // Locally support exclude as it seem broken from createComponentMetaCheckerByJsonConfig
-        if (exclude.find((excludePath) => component.filePath.includes(excludePath))) { return acc }
+        if (exclude.find(excludePath => component.filePath.includes(excludePath))) { return acc }
 
         if (!component.filePath || !component.pascalName) { return acc }
 
@@ -149,18 +149,17 @@ export function useComponentMetaParser(
 
       components[component.pascalName] = component
     } catch (e) {
-      // eslint-disable-next-line no-console
       !debug && logger.info(`Could not parse ${component?.pascalName || component?.filePath || 'a component'}!`)
     }
     const endTime = performance.now()
-    if (debug === 2) logger.success(`${component?.pascalName || component?.filePath || 'a component'} metas parsed in ${(endTime - startTime).toFixed(2)}ms`)
+    if (debug === 2) { logger.success(`${component?.pascalName || component?.filePath || 'a component'} metas parsed in ${(endTime - startTime).toFixed(2)}ms`) }
   }
 
   const fetchComponents = async () => {
     const startTime = performance.now()
     await Promise.all(Object.values(components).map(fetchComponent))
     const endTime = performance.now()
-    if (!debug) logger.success(`Components metas parsed in ${(endTime - startTime).toFixed(2)}ms`)
+    if (!debug) { logger.success(`Components metas parsed in ${(endTime - startTime).toFixed(2)}ms`) }
   }
 
   return {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -1,154 +1,21 @@
-import fsp from 'fs/promises'
 import { createUnplugin } from 'unplugin'
-import { createComponentMetaCheckerByJsonConfig } from 'vue-component-meta'
-import { resolveModule } from '@nuxt/kit'
-import { join } from 'pathe'
-import { ModuleOptions } from './options'
+import { ComponentMetaParser } from './parser'
 
-export const metaPlugin = createUnplugin<Required<ModuleOptions>>(
+export const metaPlugin = createUnplugin<{ parser: ComponentMetaParser }>(
   (options) => {
-    const outputPath = join(options.outputDir, 'component-meta')
-
-    /**
-     * Initialize component data object from components
-     */
-    const components = {
-      ...(options?.components || []).reduce(
-        (acc: any, component: any) => {
-          if (!component.filePath || !component.pascalName) { return acc }
-
-          const filePath = resolveModule(component.filePath, { paths: [options.rootDir] })
-
-          acc[component.pascalName] = {
-            ...component,
-            fullPath: filePath,
-            filePath: filePath.replace(options.rootDir, ''),
-            meta: {
-              props: [],
-              slots: [],
-              events: [],
-              exposed: []
-            }
-          }
-
-          return acc
-        },
-        {}
-      )
-    }
-
-    const getComponents = () => components
-
-    const getStringifiedComponents = () => JSON.stringify(getComponents(), null, 2)
-
-    const getVirtualModuleContent = () => `export default ${getStringifiedComponents()}`
-
-    const checker = createComponentMetaCheckerByJsonConfig(
-      options.rootDir,
-      {
-        extends: `${options?.rootDir}/tsconfig.json`,
-        skipLibCheck: false,
-        include: [
-          '**/*',
-          ...options?.componentDirs.map(dir => `${typeof dir === 'string' ? dir : (dir?.path || '')}/**/*`)
-        ],
-        exclude: []
-      },
-      options.checkerOptions
-    )
-
-    /**
-     * Output is needed for Nitro
-     */
-    const updateOutput = async () => {
-      // Main export of component data
-      await fsp.writeFile(
-        outputPath + '.mjs',
-        getVirtualModuleContent(),
-        'utf-8'
-      )
-    }
-
-    const fetchComponent = async (component: string | any) => {
-      try {
-        if (typeof component === 'string') {
-          if (components[component]) {
-            component = components[component]
-          } else {
-            component = Object.entries(components).find(([, comp]: any) => (comp.fullPath === component))
-
-            // No component found via string
-            if (!component) { return }
-
-            component = component[1]
-          }
-        }
-
-        // Component is missing required values
-        if (!component?.fullPath || !component?.pascalName) { return }
-
-        // Read component code
-        let code = await fsp.readFile(component.fullPath, 'utf-8')
-
-        // Support transformers
-        if (options?.transformers && options.transformers.length > 0) {
-          for (const transform of options.transformers) {
-            const transformResult = transform(component, code)
-            component = transformResult?.component || component
-            code = transformResult?.code || code
-          }
-        }
-
-        // Ensure file is updated
-        checker.updateFile(component.fullPath, code)
-
-        const { props, slots, events, exposed } = checker.getComponentMeta(component.fullPath)
-
-        component.meta.slots = slots
-        component.meta.events = events
-        component.meta.exposed = exposed
-        component.meta.props = props
-          .filter(prop => !prop.global)
-          .sort((a, b) => {
-            // sort required properties first
-            if (!a.required && b.required) {
-              return 1
-            }
-            if (a.required && !b.required) {
-              return -1
-            }
-            // then ensure boolean properties are sorted last
-            if (a.type === 'boolean' && b.type !== 'boolean') {
-              return 1
-            }
-            if (a.type !== 'boolean' && b.type === 'boolean') {
-              return -1
-            }
-
-            return 0
-          })
-
-        components[component.pascalName] = component
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        !options?.silent && console.log(`Could not parse ${component?.pascalName || component?.filePath || 'a component'}!`)
-      }
-    }
-
-    const fetchComponents = () => Promise.all(Object.values(components).map(fetchComponent))
-
+    const parser = options.parser
     return {
       name: 'vite-plugin-nuxt-component-meta',
       enforce: 'post',
       async buildStart () {
-        await fetchComponents()
-        await updateOutput()
+        await parser.fetchComponents()
+        await parser.updateOutput()
       },
       vite: {
         async handleHotUpdate ({ file }) {
-          if (Object.entries(components).some(([, comp]: any) => comp.fullPath === file)) {
-            await fetchComponent(file)
-            await updateOutput()
+          if (Object.entries(parser.getComponents()).some(([, comp]: any) => comp.fullPath === file)) {
+            await parser.fetchComponent(file)
+            await parser.updateOutput()
           }
         }
       }

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -68,7 +68,6 @@ describe('fixtures:basic', async () => {
     expect(Array.isArray(component.meta.props)).toBeTruthy()
     expect(component.meta).ownProperty('slots')
     expect(Array.isArray(component.meta.slots)).toBeTruthy()
-
     expect(component).toMatchObject({
       global: true,
       pascalName: 'TestContent'


### PR DESCRIPTION
Hey; preparing v0.4.0 release

- Move parsing logic into single file
- Start parsing components right after initial `components` path are resolved
- Replace `silent` for debug, supports `false`, `true` and `2`
   - `false` will hide all errors/debug messages
   - `true` will show global parse time and parsing errors
   - `2` displays parsing timings for each component, this made me find potential optimizations
- Expose `useComponentMetaParser` composable from `nuxt-component-meta/parser` for outside usage

---

@antfu ; do you think it would be possible to start the parsing asynchronously when components are resolved and use HMR API to send the result parsed to runtime?

Another way of not blocking the dev server would maybe be to switch for a `.nuxt/component-meta/{ComponentName}.js` structure instead of a single global file and use `transform` step to parse?

That would also force the parsing to only be done on components that are actually used in the stack?

Looking for suggestions on this, as I think it could be really great being able to run this module in development too, but it is currently too harmful for startup time.