### PR TITLE
fix: try to only parse meta once during ssr build

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -184,7 +184,7 @@ export function useComponentMetaParser (
     const startTime = performance.now()
     await Promise.all(Object.values(components).map(fetchComponent))
     const endTime = performance.now()
-    if (!debug) { logger.success(`Components metas parsed in ${(endTime - startTime).toFixed(2)}ms`) }
+    if (!debug || debug === 2) { logger.success(`Components metas parsed in ${(endTime - startTime).toFixed(2)}ms`) }
   }
 
   return {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -14,7 +14,7 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(
       enforce: 'post',
       async buildStart () {
         // avoid parsing meta twice
-        if (_configResolved && !_configResolved.build.ssr) {
+        if (_configResolved?.build.ssr) {
           return
         }
         await instance.fetchComponents()

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -14,7 +14,7 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(
       enforce: 'post',
       async buildStart () {
         // avoid parsing meta twice
-        if (_configResolved && !_configResolved.build.ssr) {
+        if (_configResolved && _configResolved.build.client && !_configResolved.build.ssr) {
           return
         }
         await instance.fetchComponents()

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -13,7 +13,7 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(
       name: 'vite-plugin-nuxt-component-meta',
       enforce: 'post',
       async buildStart () {
-        // avoid parsing meta twice
+        // avoid parsing meta twice in SSR
         if (_configResolved?.build.ssr) {
           return
         }

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -14,7 +14,7 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(
       enforce: 'post',
       async buildStart () {
         // avoid parsing meta twice
-        if (_configResolved && _configResolved.build.client && !_configResolved.build.ssr) {
+        if (_configResolved && !_configResolved.build.ssr) {
           return
         }
         await instance.fetchComponents()

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -7,15 +7,23 @@ type ComponentMetaUnpluginOptions = { parser?: ComponentMetaParser } & ModuleOpt
 export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(
   ({ parser, ...options }) => {
     const instance = (parser || useComponentMetaParser(options)) as ComponentMetaParser
+    let _configResolved: any
 
     return {
       name: 'vite-plugin-nuxt-component-meta',
       enforce: 'post',
       async buildStart () {
+        // avoid parsing meta twice
+        if (_configResolved && !_configResolved.build.ssr) {
+          return
+        }
         await instance.fetchComponents()
         await instance.updateOutput()
       },
       vite: {
+        configResolved (config) {
+          _configResolved = config
+        },
         async handleHotUpdate ({ file }) {
           if (Object.entries(instance.components).some(([, comp]: any) => comp.fullPath === file)) {
             await instance.fetchComponent(file)


### PR DESCRIPTION
Since result is written to disk and only used by nitro, we can avoid computing it twice