### PR TITLE
feat(module): `metaFields` option to exclude fields from output

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,6 +28,12 @@ export default defineNuxtModule<ModuleOptions>({
     components: [],
     silent: true,
     exclude: ['nuxt/dist/app/components/client-only', 'nuxt/dist/app/components/dev-only'],
+    metaFields: {
+      props: true,
+      slots: true,
+      events: true,
+      exposed: true
+    },
     transformers: [
       // @nuxt/content support
       (component, code) => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -46,7 +46,16 @@ export interface ModuleOptions {
   /**
    * Filter all components that are not global.
    */
-  globalsOnly?: boolean
+  globalsOnly?: boolean,
+  /**
+   * Filter meta properties to be included in the output.
+   */
+  metaFields: {
+    props: boolean,
+    slots: boolean,
+    events: boolean,
+    exposed: boolean
+  },
 }
 
 export interface ModuleHooks {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,7 +16,8 @@ export function useComponentMetaParser (
     checkerOptions,
     exclude = [],
     transformers = [],
-    debug = false
+    debug = false,
+    metaFields
   }: ModuleOptions
 ) {
   const logger = consola.withScope('nuxt-component-meta')
@@ -159,10 +160,10 @@ export function useComponentMetaParser (
 
       const { props, slots, events, exposed } = checker.getComponentMeta(component.fullPath)
 
-      component.meta.slots = slots
-      component.meta.events = events
-      component.meta.exposed = exposed
-      component.meta.props = props
+      component.meta.slots = metaFields.slots ? slots : []
+      component.meta.events = metaFields.events ? events : []
+      component.meta.exposed = metaFields.exposed ? exposed : []
+      component.meta.props = (metaFields.props ? props : [])
         .filter(prop => !prop.global)
         .sort((a, b) => {
           // sort required properties first


### PR DESCRIPTION
There are some situations that user wants to exclude some fields from generated JSON, like `exposed` and `events` fields which has very little use cases.

Potentially, these extra fields improved the chance of generating a pretty big object which broke the generation. Like https://github.com/nuxtlabs/ui/pull/191