### PR TITLE
fix: transform `useSlots` usages into dummy `<slot />` in templates

### DIFF
--- a/playground/components/content/UseSlots.vue
+++ b/playground/components/content/UseSlots.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    Dummy component to test useSlots
+  </div>
+</template>
+
+<script setup lang="ts">
+const slots = useSlots()
+
+const defaultSlot = computed(() => slots.default?.())
+
+</script>

--- a/playground/components/content/UseSlotsDestructuring.vue
+++ b/playground/components/content/UseSlotsDestructuring.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    Dummy component to test useSlots
+  </div>
+</template>
+
+<script setup lang="ts">
+const { title, default: dd } = useSlots()
+</script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -52,6 +52,15 @@ export default defineNuxtModule<ModuleOptions>({
             return `<slot ${slotName === 'default' ? '' : `name="${slotName}"`} />`
           }
         )
+        // handle `useSlots` helper & `$slots` alias
+        const name = code.match(/const ([a-zA-Z][a-zA-Z-_0-9]*) = useSlots\(\)/)?.[1] || '$slots'
+        const _slots = code.match(new RegExp(`${name}\\.[a-zA-Z]+`, 'gm'))
+        if (_slots) {
+          const slots = _slots
+            .map(s => s.replace(name + '.', ''))
+            .map(s => `<slot name="${s}" />`)
+          code = code.replace(/<template>/, `<template>\n${slots.join('\n')}\n`)
+        }
 
         return { component, code }
       }


### PR DESCRIPTION
- transform `useSlots` usages into dummy `<slot />` in templates


TODO:

- [x] handle destructor pattern:  `const { default } = useSlots()`