### PR TITLE
fix: don't rely on presence of `@nuxt/ui-templates`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import {
   addServerHandler,
   createResolver,
   defineNuxtModule,
-  resolveModule,
+  tryResolveModule,
   addImportsDir,
   addTemplate
 } from '@nuxt/kit'
@@ -111,13 +111,16 @@ export default defineNuxtModule<ModuleOptions>({
     let components: Component[] = []
     let metaSources: NuxtComponentMeta = {}
 
+    const uiTemplatesPath = await tryResolveModule('@nuxt/ui-templates')
     nuxt.hook('components:dirs', (dirs) => {
       componentDirs = [
         ...componentDirs,
         ...dirs,
-        { path: resolveModule('nuxt').replace('/index.mjs', '/app') },
-        { path: resolveModule('@nuxt/ui-templates').replace('/index.mjs', '/templates') }
+        { path: nuxt.options.appDir }
       ]
+      if (uiTemplatesPath) {
+        componentDirs.push({ path: uiTemplatesPath.replace('/index.mjs', '/templates') })
+      }
       parserOptions.componentDirs = componentDirs
     })
 


### PR DESCRIPTION
Several fixes in this PR:

1. Don't rely on `@nuxt/ui-templates` being present in the repo. We've recently removed it and this is breaking projects using `nuxt-component-meta`: see https://github.com/nuxt/ecosystem-ci/actions/runs/8934318864
2. We don't need to resolve `nuxt/app` as it is already set in `nuxt.options.appDir`
3. We can resolve both paths up-front and improve performance as it no longer has to run each time that `components:dirs` is called.