### PR TITLE
fix: use `mlly` rather than deprecated kit cjs util

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.9.1",
     "citty": "^0.1.5",
+    "mlly": "^1.7.1",
     "scule": "^1.1.1",
     "typescript": "^5.3.3",
     "vue-component-meta": "^1.8.27"
@@ -52,7 +53,6 @@
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "changelogen": "^0.5.5",
     "eslint": "^8.56.0",
-    "jiti": "^1.21.0",
     "nuxt": "^3.9.1",
     "release-it": "^17.0.1",
     "vitest": "^1.1.3",
@@ -76,7 +76,6 @@
       "defu",
       "unplugin",
       "consola",
-      "mlly",
       "acorn",
       "pkg-types",
       "jsonc-parser"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
     "changelogen": "^0.5.5",
     "eslint": "^8.56.0",
+    "jiti": "^1.21.0",
     "nuxt": "^3.9.1",
     "release-it": "^17.0.1",
     "vitest": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
+      jiti:
+        specifier: ^1.21.0
+        version: 1.21.0
       nuxt:
         specifier: ^3.9.1
         version: 3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,13 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^3.9.1
-        version: 3.9.1(rollup@3.29.4)
+        version: 3.9.1(rollup@4.9.1)
       citty:
         specifier: ^0.1.5
         version: 0.1.5
+      mlly:
+        specifier: ^1.7.1
+        version: 1.7.1
       scule:
         specifier: ^1.1.1
         version: 1.1.1
@@ -26,16 +29,16 @@ importers:
     devDependencies:
       '@iconify/vue':
         specifier: ^4.1.1
-        version: 4.1.1(vue@3.4.7)
+        version: 4.1.1(vue@3.4.7(typescript@5.3.3))
       '@nuxt/content':
         specifier: ^2.10.0
-        version: 2.10.0(nuxt@3.9.1)(rollup@3.29.4)(vue@3.4.7)
+        version: 2.10.0(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))
       '@nuxt/module-builder':
         specifier: ^0.5.5
-        version: 0.5.5(@nuxt/kit@3.9.1)(nuxi@3.10.0)(typescript@5.3.3)
+        version: 0.5.5(@nuxt/kit@3.9.1(rollup@4.9.1))(nuxi@3.10.0)(typescript@5.3.3)
       '@nuxt/test-utils':
         specifier: ^3.9.0
-        version: 3.9.0(h3@1.9.0)(rollup@3.29.4)(vite@5.0.10)(vitest@1.1.3)(vue-router@4.2.5)(vue@3.4.7)
+        version: 3.9.0(h3@1.10.0)(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0))(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3))
       '@nuxtjs/eslint-config-typescript':
         specifier: ^12.1.0
         version: 12.1.0(eslint@8.56.0)(typescript@5.3.3)
@@ -45,18 +48,15 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
-      jiti:
-        specifier: ^1.21.0
-        version: 1.21.0
       nuxt:
         specifier: ^3.9.1
-        version: 3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
+        version: 3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
       release-it:
         specifier: ^17.0.1
         version: 17.0.1(typescript@5.3.3)
       vitest:
         specifier: ^1.1.3
-        version: 1.1.3
+        version: 1.1.3(@types/node@20.10.5)(terser@5.26.0)
       vue:
         specifier: ^3.4.7
         version: 3.4.7(typescript@5.3.3)
@@ -65,22 +65,22 @@ importers:
     devDependencies:
       '@nuxt/content':
         specifier: ^2.3.0
-        version: 2.10.0(nuxt@3.9.0)(rollup@3.29.4)(vue@3.4.7)
+        version: 2.10.0(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))
       nuxt:
         specifier: ^3.0.0
-        version: 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
+        version: 3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       nuxt-component-meta:
         specifier: '*'
-        version: link:..
+        version: 0.7.0(rollup@4.9.1)
 
   test/fixtures/basic:
     devDependencies:
       nuxt:
         specifier: ^3.0.0-rc.12
-        version: 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
+        version: 3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       nuxt-component-meta:
         specifier: '*'
-        version: link:../../..
+        version: 0.7.0(rollup@4.9.1)
 
 packages:
 
@@ -1599,9 +1599,6 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
@@ -1899,6 +1896,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.7:
+    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -1959,9 +1959,6 @@ packages:
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -1988,45 +1985,30 @@ packages:
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   cssnano-preset-default@6.0.3:
     resolution: {integrity: sha512-4y3H370aZCkT9Ev8P4SO4bZbt+AExeKhh8wTbms/X7OLDo5E7AYUUy6YPxa/uF5Grf+AJwNcCnxKhZynJ6luBA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   cssnano-utils@4.0.1:
     resolution: {integrity: sha512-6qQuYDqsGoiXssZ3zct6dcMxiqfT6epy7x4R0TQJadd4LWO3sPR6JH6ZByOvVLoZ6EdwPGgd7+DR1EmX3tiXQQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   cssnano@6.0.2:
     resolution: {integrity: sha512-Tu9wv8UdN6CoiQnIVkCNvi+0rw/BwFWOJBlg2bVfEyKaadSuE3Gq/DD8tniVvggTJGwK88UjqZp7zL5sv6t1aA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   cssnano@6.0.3:
     resolution: {integrity: sha512-MRq4CIj8pnyZpcI2qs6wswoYoDD1t0aL28n+41c1Ukcpm56m1h6mCexIHBGjfZfnTqtGSSCP4/fB1ovxgjBOiw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
@@ -3691,6 +3673,9 @@ packages:
   mlly@1.4.2:
     resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
 
+  mlly@1.7.1:
+    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -3867,6 +3852,10 @@ packages:
   nuxi@3.10.0:
     resolution: {integrity: sha512-veZXw2NuaQ1PrpvHrnQ1dPgkAjv0WqPlvFReg5Iubum0QVGWdJJvGuNsltDQyPcZ7X7mhMXq9SLIpokK4kpvKA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+    hasBin: true
+
+  nuxt-component-meta@0.7.0:
+    resolution: {integrity: sha512-LuJWMXhe37w0nFvz+26t/u+bp9x+cXEW5O4lpZ0aF64LKSrpUTnPDXTuA0iwDzuKH0g3bhnOR7RwoyL4PEKvHw==}
     hasBin: true
 
   nuxt@3.9.0:
@@ -4098,6 +4087,9 @@ packages:
   pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
@@ -4114,6 +4106,9 @@ packages:
   pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
 
+  pkg-types@1.1.3:
+    resolution: {integrity: sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==}
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -4123,306 +4118,204 @@ packages:
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.2
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-colormin@6.0.1:
     resolution: {integrity: sha512-Tb9aR2wCJCzKuNjIeMzVNd0nXjQy25HDgFmmaRsHnP0eP/k8uQWE4S8voX5S2coO5CeKrp+USFs1Ayv9Tpxx6w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-colormin@6.0.2:
     resolution: {integrity: sha512-TXKOxs9LWcdYo5cgmcSHPkyrLAh86hX1ijmyy6J8SbOhyv6ua053M3ZAM/0j44UsnQNIWdl8gb5L7xX2htKeLw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-convert-values@6.0.1:
     resolution: {integrity: sha512-zTd4Vh0HxGkhg5aHtfCogcRHzGkvblfdWlQ53lIh1cJhYcGyIxh2hgtKoVh40AMktRERet+JKdB04nNG19kjmA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-convert-values@6.0.2:
     resolution: {integrity: sha512-aeBmaTnGQ+NUSVQT8aY0sKyAD/BaLJenEKZ03YK0JnDE1w1Rr8XShoxdal2V2H26xTJKr3v5haByOhJuyT4UYw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-discard-comments@6.0.1:
     resolution: {integrity: sha512-f1KYNPtqYLUeZGCHQPKzzFtsHaRuECe6jLakf/RjSRqvF5XHLZnM2+fXLhb8Qh/HBFHs3M4cSLb1k3B899RYIg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-discard-duplicates@6.0.1:
     resolution: {integrity: sha512-1hvUs76HLYR8zkScbwyJ8oJEugfPV+WchpnA+26fpJ7Smzs51CzGBHC32RS03psuX/2l0l0UKh2StzNxOrKCYg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-discard-empty@6.0.1:
     resolution: {integrity: sha512-yitcmKwmVWtNsrrRqGJ7/C0YRy53i0mjexBDQ9zYxDwTWVBgbU4+C9jIZLmQlTDT9zhml+u0OMFJh8+31krmOg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-discard-overridden@6.0.1:
     resolution: {integrity: sha512-qs0ehZMMZpSESbRkw1+inkf51kak6OOzNRaoLd/U7Fatp0aN2HQ1rxGOrJvYcRAN9VpX8kUF13R2ofn8OlvFVA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-merge-longhand@6.0.1:
     resolution: {integrity: sha512-vmr/HZQzaPXc45FRvSctqFTF05UaDnTn5ABX+UtQPJznDWT/QaFbVc/pJ5C2YPxx2J2XcfmWowlKwtCDwiQ5hA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-merge-longhand@6.0.2:
     resolution: {integrity: sha512-+yfVB7gEM8SrCo9w2lCApKIEzrTKl5yS1F4yGhV3kSim6JzbfLGJyhR1B6X+6vOT0U33Mgx7iv4X9MVWuaSAfw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-merge-rules@6.0.2:
     resolution: {integrity: sha512-6lm8bl0UfriSfxI+F/cezrebqqP8w702UC6SjZlUlBYwuRVNbmgcJuQU7yePIvD4MNT53r/acQCUAyulrpgmeQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-merge-rules@6.0.3:
     resolution: {integrity: sha512-yfkDqSHGohy8sGYIJwBmIGDv4K4/WrJPX355XrxQb/CSsT4Kc/RxDi6akqn5s9bap85AWgv21ArcUWwWdGNSHA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-font-values@6.0.1:
     resolution: {integrity: sha512-tIwmF1zUPoN6xOtA/2FgVk1ZKrLcCvE0dpZLtzyyte0j9zUeB8RTbCqrHZGjJlxOvNWKMYtunLrrl7HPOiR46w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-gradients@6.0.1:
     resolution: {integrity: sha512-M1RJWVjd6IOLPl1hYiOd5HQHgpp6cvJVLrieQYS9y07Yo8itAr6jaekzJphaJFR0tcg4kRewCk3kna9uHBxn/w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-params@6.0.1:
     resolution: {integrity: sha512-eFvGWArqh4khPIgPDu6SZNcaLctx97nO7c59OXnRtGntAp5/VS4gjMhhW9qUFsK6mQ27pEZGt2kR+mPizI+Z9g==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-params@6.0.2:
     resolution: {integrity: sha512-zwQtbrPEBDj+ApELZ6QylLf2/c5zmASoOuA4DzolyVGdV38iR2I5QRMsZcHkcdkZzxpN8RS4cN7LPskOkTwTZw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-selectors@6.0.1:
     resolution: {integrity: sha512-mfReq5wrS6vkunxvJp6GDuOk+Ak6JV7134gp8L+ANRnV9VwqzTvBtX6lpohooVU750AR0D3pVx2Zn6uCCwOAfQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-minify-selectors@6.0.2:
     resolution: {integrity: sha512-0b+m+w7OAvZejPQdN2GjsXLv5o0jqYHX3aoV0e7RBKPCsB7TYG5KKWBFhGnB/iP3213Ts8c5H4wLPLMm7z28Sg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-nested@6.0.1:
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-charset@6.0.1:
     resolution: {integrity: sha512-aW5LbMNRZ+oDV57PF9K+WI1Z8MPnF+A8qbajg/T8PP126YrGX1f9IQx21GI2OlGz7XFJi/fNi0GTbY948XJtXg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-display-values@6.0.1:
     resolution: {integrity: sha512-mc3vxp2bEuCb4LgCcmG1y6lKJu1Co8T+rKHrcbShJwUmKJiEl761qb/QQCfFwlrvSeET3jksolCR/RZuMURudw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-positions@6.0.1:
     resolution: {integrity: sha512-HRsq8u/0unKNvm0cvwxcOUEcakFXqZ41fv3FOdPn916XFUrympjr+03oaLkuZENz3HE9RrQE9yU0Xv43ThWjQg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-repeat-style@6.0.1:
     resolution: {integrity: sha512-Gbb2nmCy6tTiA7Sh2MBs3fj9W8swonk6lw+dFFeQT68B0Pzwp1kvisJQkdV6rbbMSd9brMlS8I8ts52tAGWmGQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-string@6.0.1:
     resolution: {integrity: sha512-5Fhx/+xzALJD9EI26Aq23hXwmv97Zfy2VFrt5PLT8lAhnBIZvmaT5pQk+NuJ/GWj/QWaKSKbnoKDGLbV6qnhXg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-timing-functions@6.0.1:
     resolution: {integrity: sha512-4zcczzHqmCU7L5dqTB9rzeqPWRMc0K2HoR+Bfl+FSMbqGBUcP5LRfgcH4BdRtLuzVQK1/FHdFoGT3F7rkEnY+g==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-unicode@6.0.1:
     resolution: {integrity: sha512-ok9DsI94nEF79MkvmLfHfn8ddnKXA7w+8YuUoz5m7b6TOdoaRCpvu/QMHXQs9+DwUbvp+ytzz04J55CPy77PuQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-unicode@6.0.2:
     resolution: {integrity: sha512-Ff2VdAYCTGyMUwpevTZPZ4w0+mPjbZzLLyoLh/RMpqUqeQKZ+xMm31hkxBavDcGKcxm6ACzGk0nBfZ8LZkStKA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-url@6.0.1:
     resolution: {integrity: sha512-jEXL15tXSvbjm0yzUV7FBiEXwhIa9H88JOXDGQzmcWoB4mSjZIsmtto066s2iW9FYuIrIF4k04HA2BKAOpbsaQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-normalize-whitespace@6.0.1:
     resolution: {integrity: sha512-76i3NpWf6bB8UHlVuLRxG4zW2YykF9CTEcq/9LGAiz2qBuX5cBStadkk0jSkg9a9TCIXbMQz7yzrygKoCW9JuA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-ordered-values@6.0.1:
     resolution: {integrity: sha512-XXbb1O/MW9HdEhnBxitZpPFbIvDgbo9NK4c/5bOfiKpnIGZDoL2xd7/e6jW5DYLsWxBbs+1nZEnVgnjnlFViaA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-reduce-initial@6.0.1:
     resolution: {integrity: sha512-cgzsI2ThG1PMSdSyM9A+bVxiiVgPIVz9f5c6H+TqEv0CA89iCOO81mwLWRWLgOKFtQkKob9nNpnkxG/1RlgFcA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-reduce-initial@6.0.2:
     resolution: {integrity: sha512-YGKalhNlCLcjcLvjU5nF8FyeCTkCO5UtvJEt0hrPZVCTtRLSOH4z00T1UntQPj4dUmIYZgMj8qK77JbSX95hSw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-reduce-transforms@6.0.1:
     resolution: {integrity: sha512-fUbV81OkUe75JM+VYO1gr/IoA2b/dRiH6HvMwhrIBSUrxq3jNZQZitSnugcTLDi1KkQh1eR/zi+iyxviUNBkcQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-selector-parser@6.0.14:
     resolution: {integrity: sha512-65xXYsT40i9GyWzlHQ5ShZoK7JZdySeOozi/tz2EezDo6c04q6+ckYMeoY7idaie1qp2dT5KoYQ2yky6JuoHnA==}
@@ -4437,36 +4330,24 @@ packages:
     engines: {node: ^14 || ^16 || >= 18}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-svgo@6.0.2:
     resolution: {integrity: sha512-IH5R9SjkTkh0kfFOQDImyy1+mTCb+E830+9SV1O+AaDcoHTvfsvt6WwJeo7KwcHbFnevZVCsXhDmjFiGVuwqFQ==}
     engines: {node: ^14 || ^16 || >= 18}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-unique-selectors@6.0.1:
     resolution: {integrity: sha512-/KCCEpNNR7oXVJ38/Id7GC9Nt0zxO1T3zVbhVaq6F6LSG+3gU3B7+QuTHfD0v8NPEHlzewAout29S0InmB78EQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-unique-selectors@6.0.2:
     resolution: {integrity: sha512-8IZGQ94nechdG7Y9Sh9FlIY2b4uS8/k8kdKRX040XHsS3B6d1HrJAkXrBSsSu4SuARruSsUjW3nlSw8BHkaAYQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -5061,18 +4942,12 @@ packages:
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   stylehacks@6.0.2:
     resolution: {integrity: sha512-00zvJGnCu64EpMjX8b5iCZ3us2Ptyw8+toEkb92VdmkEaRaSGBNKAoK6aWZckhXxmQP8zWiTaFaiMGIU8Ve8sg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.4.31
-    peerDependenciesMeta:
-      postcss:
-        optional: true
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -5246,6 +5121,9 @@ packages:
 
   ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
+
+  ufo@1.5.3:
+    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
   ultrahtml@1.5.2:
     resolution: {integrity: sha512-qh4mBffhlkiXwDAOxvSGxhL0QEQsTbnP9BozOK3OYPEGvPvdWzvAUaXNtUSMdNsKDtuyjEbyVUPFZ52SSLhLqw==}
@@ -6227,7 +6105,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/vue@4.1.1(vue@3.4.7)':
+  '@iconify/vue@4.1.1(vue@3.4.7(typescript@5.3.3))':
     dependencies:
       '@iconify/types': 2.0.0
       vue: 3.4.7(typescript@5.3.3)
@@ -6281,12 +6159,12 @@ snapshots:
     dependencies:
       call-bind: 1.0.5
 
-  '@mapbox/node-pre-gyp@1.0.11':
+  '@mapbox/node-pre-gyp@1.0.11(encoding@0.1.13)':
     dependencies:
       detect-libc: 2.0.2
       https-proxy-agent: 5.0.1
       make-dir: 3.1.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
@@ -6368,13 +6246,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nuxt/content@2.10.0(nuxt@3.9.0)(rollup@3.29.4)(vue@3.4.7)':
+  '@nuxt/content@2.10.0(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.0(rollup@3.29.4)
-      '@nuxtjs/mdc': 0.3.0(rollup@3.29.4)
-      '@vueuse/core': 10.7.1(vue@3.4.7)
-      '@vueuse/head': 2.0.0(vue@3.4.7)
-      '@vueuse/nuxt': 10.7.1(nuxt@3.9.0)(rollup@3.29.4)(vue@3.4.7)
+      '@nuxt/kit': 3.9.0(rollup@4.9.1)
+      '@nuxtjs/mdc': 0.3.0(rollup@4.9.1)
+      '@vueuse/core': 10.7.1(vue@3.3.13(typescript@5.3.3))
+      '@vueuse/head': 2.0.0(vue@3.3.13(typescript@5.3.3))
+      '@vueuse/nuxt': 10.7.1(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))
       consola: 3.2.3
       defu: 6.1.3
       destr: 2.0.2
@@ -6418,13 +6296,13 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/content@2.10.0(nuxt@3.9.1)(rollup@3.29.4)(vue@3.4.7)':
+  '@nuxt/content@2.10.0(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@nuxtjs/mdc': 0.3.0(rollup@3.29.4)
-      '@vueuse/core': 10.7.1(vue@3.4.7)
-      '@vueuse/head': 2.0.0(vue@3.4.7)
-      '@vueuse/nuxt': 10.7.1(nuxt@3.9.1)(rollup@3.29.4)(vue@3.4.7)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@nuxtjs/mdc': 0.3.0(rollup@4.9.1)
+      '@vueuse/core': 10.7.1(vue@3.4.7(typescript@5.3.3))
+      '@vueuse/head': 2.0.0(vue@3.4.7(typescript@5.3.3))
+      '@vueuse/nuxt': 10.7.1(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))
       consola: 3.2.3
       defu: 6.1.3
       destr: 2.0.2
@@ -6470,24 +6348,24 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.0.6(nuxt@3.9.0)(rollup@3.29.4)(vite@5.0.10)':
+  '@nuxt/devtools-kit@1.0.6(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@nuxt/schema': 3.9.0(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@nuxt/schema': 3.9.0(rollup@4.9.1)
       execa: 7.2.0
-      nuxt: 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
-      vite: 5.0.10
+      nuxt: 3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.0.6(nuxt@3.9.1)(rollup@3.29.4)(vite@5.0.10)':
+  '@nuxt/devtools-kit@1.0.6(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@nuxt/schema': 3.9.0(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@nuxt/schema': 3.9.0(rollup@4.9.1)
       execa: 7.2.0
-      nuxt: 3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
-      vite: 5.0.10
+      nuxt: 3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -6505,12 +6383,12 @@ snapshots:
       rc9: 2.1.1
       semver: 7.5.4
 
-  '@nuxt/devtools@1.0.6(nuxt@3.9.0)(rollup@3.29.4)(vite@5.0.10)':
+  '@nuxt/devtools@1.0.6(encoding@0.1.13)(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.0.6(nuxt@3.9.0)(rollup@3.29.4)(vite@5.0.10)
+      '@nuxt/devtools-kit': 1.0.6(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       '@nuxt/devtools-wizard': 1.0.6
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
       birpc: 0.2.14
       consola: 3.2.3
       destr: 2.0.2
@@ -6526,8 +6404,8 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.2
-      nitropack: 2.8.1
-      nuxt: 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
+      nitropack: 2.8.1(encoding@0.1.13)
+      nuxt: 3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       nypm: 0.3.3
       ofetch: 1.3.3
       ohash: 1.1.3
@@ -6540,10 +6418,10 @@ snapshots:
       semver: 7.5.4
       simple-git: 3.21.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@3.29.4)
-      vite: 5.0.10
-      vite-plugin-inspect: 0.8.1(@nuxt/kit@3.9.1)(rollup@3.29.4)(vite@5.0.10)
-      vite-plugin-vue-inspector: 4.0.2(vite@5.0.10)
+      unimport: 3.7.1(rollup@4.9.1)
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
+      vite-plugin-inspect: 0.8.1(@nuxt/kit@3.9.1(rollup@4.9.1))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -6567,12 +6445,12 @@ snapshots:
       - utf-8-validate
       - xml2js
 
-  '@nuxt/devtools@1.0.6(nuxt@3.9.1)(rollup@3.29.4)(vite@5.0.10)':
+  '@nuxt/devtools@1.0.6(encoding@0.1.13)(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.0.6(nuxt@3.9.1)(rollup@3.29.4)(vite@5.0.10)
+      '@nuxt/devtools-kit': 1.0.6(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
       '@nuxt/devtools-wizard': 1.0.6
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
       birpc: 0.2.14
       consola: 3.2.3
       destr: 2.0.2
@@ -6581,16 +6459,16 @@ snapshots:
       fast-glob: 3.3.2
       flatted: 3.2.9
       get-port-please: 3.1.1
-      h3: 1.10.0
+      h3: 1.9.0
       hookable: 5.5.3
       image-meta: 0.2.0
       is-installed-globally: 1.0.0
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.2
-      nitropack: 2.8.1
-      nuxt: 3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
-      nypm: 0.3.4
+      nitropack: 2.8.1(encoding@0.1.13)
+      nuxt: 3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
+      nypm: 0.3.3
       ofetch: 1.3.3
       ohash: 1.1.3
       pacote: 17.0.5
@@ -6602,10 +6480,10 @@ snapshots:
       semver: 7.5.4
       simple-git: 3.21.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@3.29.4)
-      vite: 5.0.10
-      vite-plugin-inspect: 0.8.1(@nuxt/kit@3.9.1)(rollup@3.29.4)(vite@5.0.10)
-      vite-plugin-vue-inspector: 4.0.2(vite@5.0.10)
+      unimport: 3.7.1(rollup@4.9.1)
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
+      vite-plugin-inspect: 0.8.1(@nuxt/kit@3.9.1(rollup@4.9.1))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -6629,9 +6507,9 @@ snapshots:
       - utf-8-validate
       - xml2js
 
-  '@nuxt/kit@3.9.0(rollup@3.29.4)':
+  '@nuxt/kit@3.9.0(rollup@4.9.1)':
     dependencies:
-      '@nuxt/schema': 3.9.0(rollup@3.29.4)
+      '@nuxt/schema': 3.9.0(rollup@4.9.1)
       c12: 1.5.1
       consola: 3.2.3
       defu: 6.1.3
@@ -6647,15 +6525,15 @@ snapshots:
       semver: 7.5.4
       ufo: 1.3.2
       unctx: 2.3.1
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.9.1(rollup@3.29.4)':
+  '@nuxt/kit@3.9.1(rollup@4.9.1)':
     dependencies:
-      '@nuxt/schema': 3.9.1(rollup@3.29.4)
+      '@nuxt/schema': 3.9.1(rollup@4.9.1)
       c12: 1.6.1
       consola: 3.2.3
       defu: 6.1.4
@@ -6671,18 +6549,18 @@ snapshots:
       semver: 7.5.4
       ufo: 1.3.2
       unctx: 2.3.1
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/module-builder@0.5.5(@nuxt/kit@3.9.1)(nuxi@3.10.0)(typescript@5.3.3)':
+  '@nuxt/module-builder@0.5.5(@nuxt/kit@3.9.1(rollup@4.9.1))(nuxi@3.10.0)(typescript@5.3.3)':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
       citty: 0.1.5
       consola: 3.2.3
-      mlly: 1.4.2
+      mlly: 1.7.1
       nuxi: 3.10.0
       pathe: 1.1.1
       unbuild: 2.0.0(typescript@5.3.3)
@@ -6691,7 +6569,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/schema@3.9.0(rollup@3.29.4)':
+  '@nuxt/schema@3.9.0(rollup@4.9.1)':
     dependencies:
       '@nuxt/ui-templates': 1.3.1
       consola: 3.2.3
@@ -6702,13 +6580,13 @@ snapshots:
       scule: 1.1.1
       std-env: 3.7.0
       ufo: 1.3.2
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.9.1(rollup@3.29.4)':
+  '@nuxt/schema@3.9.1(rollup@4.9.1)':
     dependencies:
       '@nuxt/ui-templates': 1.3.1
       consola: 3.2.3
@@ -6719,15 +6597,15 @@ snapshots:
       scule: 1.1.1
       std-env: 3.7.0
       ufo: 1.3.2
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.5.3(rollup@3.29.4)':
+  '@nuxt/telemetry@2.5.3(rollup@4.9.1)':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -6748,10 +6626,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/test-utils@3.9.0(h3@1.9.0)(rollup@3.29.4)(vite@5.0.10)(vitest@1.1.3)(vue-router@4.2.5)(vue@3.4.7)':
+  '@nuxt/test-utils@3.9.0(h3@1.10.0)(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0))(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@nuxt/schema': 3.9.0(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@nuxt/schema': 3.9.0(rollup@4.9.1)
       c12: 1.5.1
       consola: 3.2.3
       defu: 6.1.3
@@ -6760,7 +6638,7 @@ snapshots:
       execa: 8.0.1
       fake-indexeddb: 5.0.1
       get-port-please: 3.1.1
-      h3: 1.9.0
+      h3: 1.10.0
       local-pkg: 0.5.0
       magic-string: 0.30.5
       node-fetch-native: 1.6.1
@@ -6773,23 +6651,24 @@ snapshots:
       ufo: 1.3.2
       unenv: 1.8.0
       unplugin: 1.6.0
-      vite: 5.0.10
-      vitest: 1.1.3
-      vitest-environment-nuxt: 1.0.0(h3@1.9.0)(rollup@3.29.4)(vite@5.0.10)(vitest@1.1.3)(vue-router@4.2.5)(vue@3.4.7)
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
+      vitest-environment-nuxt: 1.0.0(h3@1.10.0)(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0))(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3))
       vue: 3.4.7(typescript@5.3.3)
-      vue-router: 4.2.5(vue@3.4.7)
+      vue-router: 4.2.5(vue@3.4.7(typescript@5.3.3))
+    optionalDependencies:
+      vitest: 1.1.3(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
   '@nuxt/ui-templates@1.3.1': {}
 
-  '@nuxt/vite-builder@3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vue@3.3.13)':
+  '@nuxt/vite-builder@3.9.0(@types/node@20.10.5)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vue@3.3.13(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.0(rollup@3.29.4)
-      '@rollup/plugin-replace': 5.0.5(rollup@3.29.4)
-      '@vitejs/plugin-vue': 5.0.0(vite@5.0.10)(vue@3.3.13)
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.0.10)(vue@3.3.13)
+      '@nuxt/kit': 3.9.0(rollup@4.9.1)
+      '@rollup/plugin-replace': 5.0.5(rollup@4.9.1)
+      '@vitejs/plugin-vue': 5.0.0(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))(vue@3.3.13(typescript@5.3.3))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))(vue@3.3.13(typescript@5.3.3))
       autoprefixer: 10.4.16(postcss@8.4.32)
       clear: 0.1.0
       consola: 3.2.3
@@ -6810,14 +6689,14 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       postcss: 8.4.32
-      rollup-plugin-visualizer: 5.12.0(rollup@3.29.4)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.9.1)
       std-env: 3.7.0
       strip-literal: 1.3.0
       ufo: 1.3.2
       unplugin: 1.6.0
-      vite: 5.0.10
-      vite-node: 1.1.0
-      vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.10)
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
+      vite-node: 1.1.0(@types/node@20.10.5)(terser@5.26.0)
+      vite-plugin-checker: 0.6.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
       vue: 3.3.13(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -6839,12 +6718,12 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxt/vite-builder@3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vue@3.4.7)':
+  '@nuxt/vite-builder@3.9.1(@types/node@20.10.5)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vue@3.4.7(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@rollup/plugin-replace': 5.0.5(rollup@3.29.4)
-      '@vitejs/plugin-vue': 5.0.2(vite@5.0.11)(vue@3.4.7)
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.0.11)(vue@3.4.7)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@rollup/plugin-replace': 5.0.5(rollup@4.9.1)
+      '@vitejs/plugin-vue': 5.0.2(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vue@3.4.7(typescript@5.3.3))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vue@3.4.7(typescript@5.3.3))
       autoprefixer: 10.4.16(postcss@8.4.33)
       clear: 0.1.0
       consola: 3.2.3
@@ -6859,20 +6738,20 @@ snapshots:
       h3: 1.10.0
       knitwork: 1.0.0
       magic-string: 0.30.5
-      mlly: 1.4.2
+      mlly: 1.7.1
       ohash: 1.1.3
       pathe: 1.1.1
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       postcss: 8.4.33
-      rollup-plugin-visualizer: 5.12.0(rollup@3.29.4)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.9.1)
       std-env: 3.7.0
       strip-literal: 2.0.0
       ufo: 1.3.2
       unplugin: 1.6.0
-      vite: 5.0.11
-      vite-node: 1.1.3
-      vite-plugin-checker: 0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.11)
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
+      vite-node: 1.1.3(@types/node@20.10.5)(terser@5.26.0)
+      vite-plugin-checker: 0.6.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
       vue: 3.4.7(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -6896,12 +6775,12 @@ snapshots:
 
   '@nuxtjs/eslint-config-typescript@12.1.0(eslint@8.56.0)(typescript@5.3.3)':
     dependencies:
-      '@nuxtjs/eslint-config': 12.0.0(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      '@typescript-eslint/eslint-plugin': 6.16.0(@typescript-eslint/parser@6.16.0)(eslint@8.56.0)(typescript@5.3.3)
+      '@nuxtjs/eslint-config': 12.0.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      '@typescript-eslint/eslint-plugin': 6.16.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.16.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-vue: 9.19.2(eslint@8.56.0)
     transitivePeerDependencies:
       - eslint-import-resolver-node
@@ -6909,11 +6788,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxtjs/eslint-config@12.0.0(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)':
+  '@nuxtjs/eslint-config@12.0.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)':
     dependencies:
       eslint: 8.56.0
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0))(eslint-plugin-n@15.7.0(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-node: 11.1.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
@@ -6926,9 +6805,9 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@nuxtjs/mdc@0.3.0(rollup@3.29.4)':
+  '@nuxtjs/mdc@0.3.0(rollup@4.9.1)':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
       '@types/hast': 3.0.3
       '@types/mdast': 4.0.3
       '@vue/compiler-core': 3.3.13
@@ -7106,13 +6985,15 @@ snapshots:
 
   '@rollup/plugin-alias@5.1.0(rollup@3.29.4)':
     dependencies:
-      rollup: 3.29.4
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 3.29.4
 
   '@rollup/plugin-alias@5.1.0(rollup@4.9.1)':
     dependencies:
-      rollup: 4.9.1
       slash: 4.0.0
+    optionalDependencies:
+      rollup: 4.9.1
 
   '@rollup/plugin-commonjs@25.0.7(rollup@3.29.4)':
     dependencies:
@@ -7122,6 +7003,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.5
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-commonjs@25.0.7(rollup@4.9.1)':
@@ -7132,6 +7014,7 @@ snapshots:
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.5
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/plugin-inject@5.0.5(rollup@4.9.1)':
@@ -7139,16 +7022,19 @@ snapshots:
       '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       estree-walker: 2.0.2
       magic-string: 0.30.5
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/plugin-json@6.1.0(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-json@6.1.0(rollup@4.9.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@3.29.4)':
@@ -7159,6 +7045,7 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@4.9.1)':
@@ -7169,30 +7056,35 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/plugin-replace@5.0.5(rollup@3.29.4)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       magic-string: 0.30.5
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/plugin-replace@5.0.5(rollup@4.9.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       magic-string: 0.30.5
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/plugin-terser@0.4.4(rollup@4.9.1)':
     dependencies:
-      rollup: 4.9.1
       serialize-javascript: 6.0.1
       smob: 1.4.1
       terser: 5.26.0
+    optionalDependencies:
+      rollup: 4.9.1
 
   '@rollup/plugin-wasm@6.2.2(rollup@4.9.1)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/pluginutils@4.2.1':
@@ -7205,6 +7097,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 3.29.4
 
   '@rollup/pluginutils@5.1.0(rollup@4.9.1)':
@@ -7212,6 +7105,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 4.9.1
 
   '@rollup/rollup-android-arm-eabi@4.9.1':
@@ -7341,7 +7235,7 @@ snapshots:
 
   '@types/web-bluetooth@0.0.20': {}
 
-  '@typescript-eslint/eslint-plugin@6.16.0(@typescript-eslint/parser@6.16.0)(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@6.16.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
@@ -7356,6 +7250,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -7368,6 +7263,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.16.0
       debug: 4.3.4
       eslint: 8.56.0
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -7384,6 +7280,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.56.0
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -7400,6 +7297,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.5.4
       ts-api-utils: 1.0.3(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -7444,7 +7342,7 @@ snapshots:
       '@unhead/schema': 1.8.9
       '@unhead/shared': 1.8.9
 
-  '@unhead/vue@1.8.9(vue@3.3.13)':
+  '@unhead/vue@1.8.9(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@unhead/schema': 1.8.9
       '@unhead/shared': 1.8.9
@@ -7452,7 +7350,7 @@ snapshots:
       unhead: 1.8.9
       vue: 3.3.13(typescript@5.3.3)
 
-  '@unhead/vue@1.8.9(vue@3.4.7)':
+  '@unhead/vue@1.8.9(vue@3.4.7(typescript@5.3.3))':
     dependencies:
       '@unhead/schema': 1.8.9
       '@unhead/shared': 1.8.9
@@ -7460,9 +7358,9 @@ snapshots:
       unhead: 1.8.9
       vue: 3.4.7(typescript@5.3.3)
 
-  '@vercel/nft@0.24.4':
+  '@vercel/nft@0.24.4(encoding@0.1.13)':
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
+      '@mapbox/node-pre-gyp': 1.0.11(encoding@0.1.13)
       '@rollup/pluginutils': 4.2.1
       acorn: 8.11.2
       async-sema: 3.1.1
@@ -7477,34 +7375,34 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.10)(vue@3.3.13)':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.6)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.6)
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
       vue: 3.3.13(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.11)(vue@3.4.7)':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vue@3.4.7(typescript@5.3.3))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.6)
       '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.6)
-      vite: 5.0.11
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
       vue: 3.4.7(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.0(vite@5.0.10)(vue@3.3.13)':
+  '@vitejs/plugin-vue@5.0.0(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))(vue@3.3.13(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
       vue: 3.3.13(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@5.0.2(vite@5.0.11)(vue@3.4.7)':
+  '@vitejs/plugin-vue@5.0.2(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vue@3.4.7(typescript@5.3.3))':
     dependencies:
-      vite: 5.0.11
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
       vue: 3.4.7(typescript@5.3.3)
 
   '@vitest/expect@1.1.3':
@@ -7549,26 +7447,28 @@ snapshots:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
 
-  '@vue-macros/common@1.10.0(rollup@3.29.4)(vue@3.3.13)':
+  '@vue-macros/common@1.10.0(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@babel/types': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       '@vue/compiler-sfc': 3.3.13
-      ast-kit: 0.11.3(rollup@3.29.4)
+      ast-kit: 0.11.3(rollup@4.9.1)
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.3.13(typescript@5.3.3)
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.10.0(rollup@3.29.4)(vue@3.4.7)':
+  '@vue-macros/common@1.10.0(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))':
     dependencies:
       '@babel/types': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       '@vue/compiler-sfc': 3.3.13
-      ast-kit: 0.11.3(rollup@3.29.4)
+      ast-kit: 0.11.3(rollup@4.9.1)
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
+    optionalDependencies:
       vue: 3.4.7(typescript@5.3.3)
     transitivePeerDependencies:
       - rollup
@@ -7662,8 +7562,9 @@ snapshots:
       minimatch: 9.0.3
       muggle-string: 0.3.1
       path-browserify: 1.0.1
-      typescript: 5.3.3
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.3.3
 
   '@vue/reactivity-transform@3.3.13':
     dependencies:
@@ -7703,13 +7604,13 @@ snapshots:
       '@vue/shared': 3.4.7
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.3.13(vue@3.3.13)':
+  '@vue/server-renderer@3.3.13(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@vue/compiler-ssr': 3.3.13
       '@vue/shared': 3.3.13
       vue: 3.3.13(typescript@5.3.3)
 
-  '@vue/server-renderer@3.4.7(vue@3.4.7)':
+  '@vue/server-renderer@3.4.7(vue@3.4.7(typescript@5.3.3))':
     dependencies:
       '@vue/compiler-ssr': 3.4.7
       '@vue/shared': 3.4.7
@@ -7719,57 +7620,82 @@ snapshots:
 
   '@vue/shared@3.4.7': {}
 
-  '@vueuse/core@10.7.1(vue@3.4.7)':
+  '@vueuse/core@10.7.1(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.7.1
-      '@vueuse/shared': 10.7.1(vue@3.4.7)
-      vue-demi: 0.14.6(vue@3.4.7)
+      '@vueuse/shared': 10.7.1(vue@3.3.13(typescript@5.3.3))
+      vue-demi: 0.14.6(vue@3.3.13(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/head@2.0.0(vue@3.4.7)':
+  '@vueuse/core@10.7.1(vue@3.4.7(typescript@5.3.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.7.1
+      '@vueuse/shared': 10.7.1(vue@3.4.7(typescript@5.3.3))
+      vue-demi: 0.14.6(vue@3.4.7(typescript@5.3.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/head@2.0.0(vue@3.3.13(typescript@5.3.3))':
     dependencies:
       '@unhead/dom': 1.8.9
       '@unhead/schema': 1.8.9
       '@unhead/ssr': 1.8.9
-      '@unhead/vue': 1.8.9(vue@3.4.7)
+      '@unhead/vue': 1.8.9(vue@3.3.13(typescript@5.3.3))
+      vue: 3.3.13(typescript@5.3.3)
+
+  '@vueuse/head@2.0.0(vue@3.4.7(typescript@5.3.3))':
+    dependencies:
+      '@unhead/dom': 1.8.9
+      '@unhead/schema': 1.8.9
+      '@unhead/ssr': 1.8.9
+      '@unhead/vue': 1.8.9(vue@3.4.7(typescript@5.3.3))
       vue: 3.4.7(typescript@5.3.3)
 
   '@vueuse/metadata@10.7.1': {}
 
-  '@vueuse/nuxt@10.7.1(nuxt@3.9.0)(rollup@3.29.4)(vue@3.4.7)':
+  '@vueuse/nuxt@10.7.1(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@vueuse/core': 10.7.1(vue@3.4.7)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@vueuse/core': 10.7.1(vue@3.3.13(typescript@5.3.3))
       '@vueuse/metadata': 10.7.1
       local-pkg: 0.5.0
-      nuxt: 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
-      vue-demi: 0.14.6(vue@3.4.7)
+      nuxt: 3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
+      vue-demi: 0.14.6(vue@3.3.13(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
       - supports-color
       - vue
 
-  '@vueuse/nuxt@10.7.1(nuxt@3.9.1)(rollup@3.29.4)(vue@3.4.7)':
+  '@vueuse/nuxt@10.7.1(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@vueuse/core': 10.7.1(vue@3.4.7)
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@vueuse/core': 10.7.1(vue@3.4.7(typescript@5.3.3))
       '@vueuse/metadata': 10.7.1
       local-pkg: 0.5.0
-      nuxt: 3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10)
-      vue-demi: 0.14.6(vue@3.4.7)
+      nuxt: 3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
+      vue-demi: 0.14.6(vue@3.4.7(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
       - supports-color
       - vue
 
-  '@vueuse/shared@10.7.1(vue@3.4.7)':
+  '@vueuse/shared@10.7.1(vue@3.3.13(typescript@5.3.3))':
     dependencies:
-      vue-demi: 0.14.6(vue@3.4.7)
+      vue-demi: 0.14.6(vue@3.3.13(typescript@5.3.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@10.7.1(vue@3.4.7(typescript@5.3.3))':
+    dependencies:
+      vue-demi: 0.14.6(vue@3.4.7(typescript@5.3.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -7930,18 +7856,18 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
-  ast-kit@0.11.3(rollup@3.29.4):
+  ast-kit@0.11.3(rollup@4.9.1):
     dependencies:
       '@babel/parser': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
 
-  ast-kit@0.9.5(rollup@3.29.4):
+  ast-kit@0.9.5(rollup@4.9.1):
     dependencies:
       '@babel/parser': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
@@ -7950,10 +7876,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  ast-walker-scope@0.5.0(rollup@3.29.4):
+  ast-walker-scope@0.5.0(rollup@4.9.1):
     dependencies:
       '@babel/parser': 7.23.6
-      ast-kit: 0.9.5(rollup@3.29.4)
+      ast-kit: 0.9.5(rollup@4.9.1)
     transitivePeerDependencies:
       - rollup
 
@@ -8089,7 +8015,7 @@ snapshots:
       dotenv: 16.3.1
       giget: 1.2.1
       jiti: 1.21.0
-      mlly: 1.4.2
+      mlly: 1.7.1
       ohash: 1.1.3
       pathe: 1.1.1
       perfect-debounce: 1.0.0
@@ -8103,7 +8029,7 @@ snapshots:
       dotenv: 16.3.1
       giget: 1.2.1
       jiti: 1.21.0
-      mlly: 1.4.2
+      mlly: 1.7.1
       ohash: 1.1.3
       pathe: 1.1.1
       perfect-debounce: 1.0.0
@@ -8318,6 +8244,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  confbox@0.1.7: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
@@ -8349,6 +8277,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.3.3
 
   crc-32@1.2.2: {}
@@ -8842,10 +8771,10 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0))(eslint-plugin-n@15.7.0(eslint@8.56.0))(eslint-plugin-promise@6.1.1(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
 
@@ -8857,13 +8786,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -8874,13 +8803,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
-      '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.16.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8896,9 +8826,8 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     dependencies:
-      '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -8907,7 +8836,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.16.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.16.0(eslint@8.56.0)(typescript@5.3.3))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -8917,6 +8846,8 @@ snapshots:
       object.values: 1.1.7
       semver: 6.3.1
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.16.0(eslint@8.56.0)(typescript@5.3.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -9119,7 +9050,7 @@ snapshots:
   externality@1.0.2:
     dependencies:
       enhanced-resolve: 5.15.0
-      mlly: 1.4.2
+      mlly: 1.7.1
       pathe: 1.1.1
       ufo: 1.3.2
 
@@ -9975,7 +9906,7 @@ snapshots:
       h3: 1.9.0
       http-shutdown: 1.2.2
       jiti: 1.21.0
-      mlly: 1.4.2
+      mlly: 1.7.1
       node-forge: 1.3.1
       pathe: 1.1.1
       std-env: 3.7.0
@@ -9987,7 +9918,7 @@ snapshots:
 
   local-pkg@0.5.0:
     dependencies:
-      mlly: 1.4.2
+      mlly: 1.7.1
       pkg-types: 1.0.3
 
   locate-path@5.0.0:
@@ -10500,11 +10431,12 @@ snapshots:
       fs-extra: 11.2.0
       globby: 13.2.2
       jiti: 1.21.0
-      mlly: 1.4.2
+      mlly: 1.7.1
       mri: 1.2.0
       pathe: 1.1.1
       postcss: 8.4.32
       postcss-nested: 6.0.1(postcss@8.4.32)
+    optionalDependencies:
       typescript: 5.3.3
 
   mlly@1.4.2:
@@ -10513,6 +10445,13 @@ snapshots:
       pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.3.2
+
+  mlly@1.7.1:
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.1.3
+      ufo: 1.5.3
 
   mri@1.2.0: {}
 
@@ -10542,7 +10481,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  nitropack@2.8.1:
+  nitropack@2.8.1(encoding@0.1.13):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.0
       '@netlify/functions': 2.4.1
@@ -10556,7 +10495,7 @@ snapshots:
       '@rollup/plugin-wasm': 6.2.2(rollup@4.9.1)
       '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       '@types/http-proxy': 1.17.14
-      '@vercel/nft': 0.24.4
+      '@vercel/nft': 0.24.4(encoding@0.1.13)
       archiver: 6.0.1
       c12: 1.6.1
       chalk: 5.3.0
@@ -10637,9 +10576,11 @@ snapshots:
 
   node-fetch-native@1.6.1: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -10759,18 +10700,29 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10):
+  nuxt-component-meta@0.7.0(rollup@4.9.1):
+    dependencies:
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      citty: 0.1.5
+      scule: 1.1.1
+      typescript: 5.3.3
+      vue-component-meta: 1.8.27(typescript@5.3.3)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.0.6(nuxt@3.9.0)(rollup@3.29.4)(vite@5.0.10)
-      '@nuxt/kit': 3.9.0(rollup@3.29.4)
-      '@nuxt/schema': 3.9.0(rollup@3.29.4)
-      '@nuxt/telemetry': 2.5.3(rollup@3.29.4)
+      '@nuxt/devtools': 1.0.6(encoding@0.1.13)(nuxt@3.9.0(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0))
+      '@nuxt/kit': 3.9.0(rollup@4.9.1)
+      '@nuxt/schema': 3.9.0(rollup@4.9.1)
+      '@nuxt/telemetry': 2.5.3(rollup@4.9.1)
       '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.9.0(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vue@3.3.13)
+      '@nuxt/vite-builder': 3.9.0(@types/node@20.10.5)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vue@3.3.13(typescript@5.3.3))
       '@unhead/dom': 1.8.9
       '@unhead/ssr': 1.8.9
-      '@unhead/vue': 1.8.9(vue@3.3.13)
+      '@unhead/vue': 1.8.9(vue@3.3.13(typescript@5.3.3))
       '@vue/shared': 3.3.13
       acorn: 8.11.2
       c12: 1.5.1
@@ -10791,7 +10743,7 @@ snapshots:
       knitwork: 1.0.0
       magic-string: 0.30.5
       mlly: 1.4.2
-      nitropack: 2.8.1
+      nitropack: 2.8.1(encoding@0.1.13)
       nuxi: 3.10.0
       nypm: 0.3.3
       ofetch: 1.3.3
@@ -10808,14 +10760,17 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.8.0
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       unplugin: 1.6.0
-      unplugin-vue-router: 0.7.0(rollup@3.29.4)(vue-router@4.2.5)(vue@3.3.13)
+      unplugin-vue-router: 0.7.0(rollup@4.9.1)(vue-router@4.2.5(vue@3.3.13(typescript@5.3.3)))(vue@3.3.13(typescript@5.3.3))
       untyped: 1.4.0
       vue: 3.3.13(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.2.5(vue@3.3.13)
+      vue-router: 4.2.5(vue@3.3.13(typescript@5.3.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.3.0
+      '@types/node': 20.10.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10852,18 +10807,18 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vite@5.0.10):
+  nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.0.6(nuxt@3.9.1)(rollup@3.29.4)(vite@5.0.10)
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@nuxt/schema': 3.9.1(rollup@3.29.4)
-      '@nuxt/telemetry': 2.5.3(rollup@3.29.4)
+      '@nuxt/devtools': 1.0.6(encoding@0.1.13)(nuxt@3.9.1(@parcel/watcher@2.3.0)(@types/node@20.10.5)(encoding@0.1.13)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+      '@nuxt/schema': 3.9.1(rollup@4.9.1)
+      '@nuxt/telemetry': 2.5.3(rollup@4.9.1)
       '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.9.1(eslint@8.56.0)(rollup@3.29.4)(typescript@5.3.3)(vue@3.4.7)
+      '@nuxt/vite-builder': 3.9.1(@types/node@20.10.5)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.9.1)(terser@5.26.0)(typescript@5.3.3)(vue@3.4.7(typescript@5.3.3))
       '@unhead/dom': 1.8.9
       '@unhead/ssr': 1.8.9
-      '@unhead/vue': 1.8.9(vue@3.4.7)
+      '@unhead/vue': 1.8.9(vue@3.4.7(typescript@5.3.3))
       '@vue/shared': 3.4.7
       acorn: 8.11.3
       c12: 1.6.1
@@ -10883,8 +10838,8 @@ snapshots:
       klona: 2.0.6
       knitwork: 1.0.0
       magic-string: 0.30.5
-      mlly: 1.4.2
-      nitropack: 2.8.1
+      mlly: 1.7.1
+      nitropack: 2.8.1(encoding@0.1.13)
       nuxi: 3.10.0
       nypm: 0.3.4
       ofetch: 1.3.3
@@ -10901,14 +10856,17 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@3.29.4)
+      unimport: 3.7.1(rollup@4.9.1)
       unplugin: 1.6.0
-      unplugin-vue-router: 0.7.0(rollup@3.29.4)(vue-router@4.2.5)(vue@3.4.7)
+      unplugin-vue-router: 0.7.0(rollup@4.9.1)(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3))
       untyped: 1.4.0
       vue: 3.4.7(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.2.5(vue@3.4.7)
+      vue-router: 4.2.5(vue@3.4.7(typescript@5.3.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.3.0
+      '@types/node': 20.10.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11219,6 +11177,8 @@ snapshots:
 
   pathe@1.1.1: {}
 
+  pathe@1.1.2: {}
+
   pathval@1.1.1: {}
 
   perfect-debounce@1.0.0: {}
@@ -11232,6 +11192,12 @@ snapshots:
       jsonc-parser: 3.2.0
       mlly: 1.4.2
       pathe: 1.1.1
+
+  pkg-types@1.1.3:
+    dependencies:
+      confbox: 0.1.7
+      mlly: 1.7.1
+      pathe: 1.1.2
 
   pluralize@8.0.0: {}
 
@@ -11906,21 +11872,14 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.23.5
 
-  rollup-plugin-visualizer@5.12.0(rollup@3.29.4):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      rollup: 3.29.4
-      source-map: 0.7.4
-      yargs: 17.7.2
-
   rollup-plugin-visualizer@5.12.0(rollup@4.9.1):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: 4.9.1
       source-map: 0.7.4
       yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.9.1
 
   rollup@3.29.4:
     optionalDependencies:
@@ -12353,7 +12312,7 @@ snapshots:
   terser@5.26.0:
     dependencies:
       '@jridgewell/source-map': 0.3.5
-      acorn: 8.11.2
+      acorn: 8.11.3
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -12465,6 +12424,8 @@ snapshots:
 
   ufo@1.3.2: {}
 
+  ufo@1.5.3: {}
+
   ultrahtml@1.5.2: {}
 
   unbox-primitive@1.0.2:
@@ -12492,15 +12453,16 @@ snapshots:
       jiti: 1.21.0
       magic-string: 0.30.5
       mkdist: 1.4.0(typescript@5.3.3)
-      mlly: 1.4.2
+      mlly: 1.7.1
       pathe: 1.1.1
       pkg-types: 1.0.3
       pretty-bytes: 6.1.1
       rollup: 3.29.4
       rollup-plugin-dts: 6.1.0(rollup@3.29.4)(typescript@5.3.3)
       scule: 1.1.1
-      typescript: 5.3.3
       untyped: 1.4.0
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - sass
       - supports-color
@@ -12556,24 +12518,6 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.1.0
       vfile: 6.0.1
-
-  unimport@3.7.1(rollup@3.29.4):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      acorn: 8.11.2
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      mlly: 1.4.2
-      pathe: 1.1.1
-      pkg-types: 1.0.3
-      scule: 1.1.1
-      strip-literal: 1.3.0
-      unplugin: 1.6.0
-    transitivePeerDependencies:
-      - rollup
 
   unimport@3.7.1(rollup@4.9.1):
     dependencies:
@@ -12638,12 +12582,12 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin-vue-router@0.7.0(rollup@3.29.4)(vue-router@4.2.5)(vue@3.3.13):
+  unplugin-vue-router@0.7.0(rollup@4.9.1)(vue-router@4.2.5(vue@3.3.13(typescript@5.3.3)))(vue@3.3.13(typescript@5.3.3)):
     dependencies:
       '@babel/types': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      '@vue-macros/common': 1.10.0(rollup@3.29.4)(vue@3.3.13)
-      ast-walker-scope: 0.5.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
+      '@vue-macros/common': 1.10.0(rollup@4.9.1)(vue@3.3.13(typescript@5.3.3))
+      ast-walker-scope: 0.5.0(rollup@4.9.1)
       chokidar: 3.5.3
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -12652,28 +12596,30 @@ snapshots:
       pathe: 1.1.1
       scule: 1.1.1
       unplugin: 1.6.0
-      vue-router: 4.2.5(vue@3.3.13)
       yaml: 2.3.4
+    optionalDependencies:
+      vue-router: 4.2.5(vue@3.3.13(typescript@5.3.3))
     transitivePeerDependencies:
       - rollup
       - vue
 
-  unplugin-vue-router@0.7.0(rollup@3.29.4)(vue-router@4.2.5)(vue@3.4.7):
+  unplugin-vue-router@0.7.0(rollup@4.9.1)(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3)):
     dependencies:
       '@babel/types': 7.23.6
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      '@vue-macros/common': 1.10.0(rollup@3.29.4)(vue@3.4.7)
-      ast-walker-scope: 0.5.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
+      '@vue-macros/common': 1.10.0(rollup@4.9.1)(vue@3.4.7(typescript@5.3.3))
+      ast-walker-scope: 0.5.0(rollup@4.9.1)
       chokidar: 3.5.3
       fast-glob: 3.3.2
       json5: 2.2.3
       local-pkg: 0.4.3
-      mlly: 1.4.2
+      mlly: 1.7.1
       pathe: 1.1.1
       scule: 1.1.1
       unplugin: 1.6.0
-      vue-router: 4.2.5(vue@3.4.7)
       yaml: 2.3.4
+    optionalDependencies:
+      vue-router: 4.2.5(vue@3.4.7(typescript@5.3.3))
     transitivePeerDependencies:
       - rollup
       - vue
@@ -12779,13 +12725,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.1.0:
+  vite-node@1.1.0(@types/node@20.10.5)(terser@5.26.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12796,13 +12742,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.1.3:
+  vite-node@1.1.3(@types/node@20.10.5)(terser@5.26.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12813,14 +12759,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.10):
+  vite-plugin-checker@0.6.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@babel/code-frame': 7.23.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       chokidar: 3.5.3
       commander: 8.3.0
-      eslint: 8.56.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       lodash.debounce: 4.0.8
@@ -12829,21 +12774,23 @@ snapshots:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      typescript: 5.3.3
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
+    optionalDependencies:
+      eslint: 8.56.0
+      optionator: 0.9.3
+      typescript: 5.3.3
 
-  vite-plugin-checker@0.6.2(eslint@8.56.0)(typescript@5.3.3)(vite@5.0.11):
+  vite-plugin-checker@0.6.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@babel/code-frame': 7.23.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       chokidar: 3.5.3
       commander: 8.3.0
-      eslint: 8.56.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       lodash.debounce: 4.0.8
@@ -12852,30 +12799,51 @@ snapshots:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
-      typescript: 5.3.3
-      vite: 5.0.11
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
+    optionalDependencies:
+      eslint: 8.56.0
+      optionator: 0.9.3
+      typescript: 5.3.3
 
-  vite-plugin-inspect@0.8.1(@nuxt/kit@3.9.1)(rollup@3.29.4)(vite@5.0.10):
+  vite-plugin-inspect@0.8.1(@nuxt/kit@3.9.1(rollup@4.9.1))(rollup@4.9.1)(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/kit': 3.9.1(rollup@3.29.4)
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-inspector@4.0.2(vite@5.0.10):
+  vite-plugin-inspect@0.8.1(@nuxt/kit@3.9.1(rollup@4.9.1))(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)):
+    dependencies:
+      '@antfu/utils': 0.7.7
+      '@rollup/pluginutils': 5.1.0(rollup@4.9.1)
+      debug: 4.3.4
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.9.1(rollup@4.9.1)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-vue-inspector@4.0.2(vite@5.0.10(@types/node@20.10.5)(terser@5.26.0)):
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-proposal-decorators': 7.23.6(@babel/core@7.23.6)
@@ -12886,29 +12854,48 @@ snapshots:
       '@vue/compiler-dom': 3.3.13
       kolorist: 1.8.0
       magic-string: 0.30.5
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.0.10:
+  vite-plugin-vue-inspector@4.0.2(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0)):
+    dependencies:
+      '@babel/core': 7.23.6
+      '@babel/plugin-proposal-decorators': 7.23.6(@babel/core@7.23.6)
+      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.23.6)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.6)
+      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.6)
+      '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.23.6)
+      '@vue/compiler-dom': 3.3.13
+      kolorist: 1.8.0
+      magic-string: 0.30.5
+      vite: 5.0.11(@types/node@20.10.5)(terser@5.26.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite@5.0.10(@types/node@20.10.5)(terser@5.26.0):
     dependencies:
       esbuild: 0.19.10
       postcss: 8.4.32
       rollup: 4.9.1
     optionalDependencies:
+      '@types/node': 20.10.5
       fsevents: 2.3.3
+      terser: 5.26.0
 
-  vite@5.0.11:
+  vite@5.0.11(@types/node@20.10.5)(terser@5.26.0):
     dependencies:
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.1
     optionalDependencies:
+      '@types/node': 20.10.5
       fsevents: 2.3.3
+      terser: 5.26.0
 
-  vitest-environment-nuxt@1.0.0(h3@1.9.0)(rollup@3.29.4)(vite@5.0.10)(vitest@1.1.3)(vue-router@4.2.5)(vue@3.4.7):
+  vitest-environment-nuxt@1.0.0(h3@1.10.0)(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0))(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3)):
     dependencies:
-      '@nuxt/test-utils': 3.9.0(h3@1.9.0)(rollup@3.29.4)(vite@5.0.10)(vitest@1.1.3)(vue-router@4.2.5)(vue@3.4.7)
+      '@nuxt/test-utils': 3.9.0(h3@1.10.0)(rollup@4.9.1)(vite@5.0.11(@types/node@20.10.5)(terser@5.26.0))(vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0))(vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)))(vue@3.4.7(typescript@5.3.3))
     transitivePeerDependencies:
       - '@jest/globals'
       - '@testing-library/vue'
@@ -12925,7 +12912,7 @@ snapshots:
       - vue
       - vue-router
 
-  vitest@1.1.3:
+  vitest@1.1.3(@types/node@20.10.5)(terser@5.26.0):
     dependencies:
       '@vitest/expect': 1.1.3
       '@vitest/runner': 1.1.3
@@ -12945,9 +12932,11 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.0.10
-      vite-node: 1.1.3
+      vite: 5.0.10(@types/node@20.10.5)(terser@5.26.0)
+      vite-node: 1.1.3(@types/node@20.10.5)(terser@5.26.0)
       why-is-node-running: 2.2.2
+    optionalDependencies:
+      '@types/node': 20.10.5
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -12989,12 +12978,17 @@ snapshots:
       '@volar/typescript': 1.11.1
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       path-browserify: 1.0.1
-      typescript: 5.3.3
       vue-component-type-helpers: 1.8.27
+    optionalDependencies:
+      typescript: 5.3.3
 
   vue-component-type-helpers@1.8.27: {}
 
-  vue-demi@0.14.6(vue@3.4.7):
+  vue-demi@0.14.6(vue@3.3.13(typescript@5.3.3)):
+    dependencies:
+      vue: 3.3.13(typescript@5.3.3)
+
+  vue-demi@0.14.6(vue@3.4.7(typescript@5.3.3)):
     dependencies:
       vue: 3.4.7(typescript@5.3.3)
 
@@ -13013,12 +13007,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.2.5(vue@3.3.13):
+  vue-router@4.2.5(vue@3.3.13(typescript@5.3.3)):
     dependencies:
       '@vue/devtools-api': 6.5.1
       vue: 3.3.13(typescript@5.3.3)
 
-  vue-router@4.2.5(vue@3.4.7):
+  vue-router@4.2.5(vue@3.4.7(typescript@5.3.3)):
     dependencies:
       '@vue/devtools-api': 6.5.1
       vue: 3.4.7(typescript@5.3.3)
@@ -13033,8 +13027,9 @@ snapshots:
       '@vue/compiler-dom': 3.3.13
       '@vue/compiler-sfc': 3.3.13
       '@vue/runtime-dom': 3.3.13
-      '@vue/server-renderer': 3.3.13(vue@3.3.13)
+      '@vue/server-renderer': 3.3.13(vue@3.3.13(typescript@5.3.3))
       '@vue/shared': 3.3.13
+    optionalDependencies:
       typescript: 5.3.3
 
   vue@3.4.7(typescript@5.3.3):
@@ -13042,8 +13037,9 @@ snapshots:
       '@vue/compiler-dom': 3.4.7
       '@vue/compiler-sfc': 3.4.7
       '@vue/runtime-dom': 3.4.7
-      '@vue/server-renderer': 3.4.7(vue@3.4.7)
+      '@vue/server-renderer': 3.4.7(vue@3.4.7(typescript@5.3.3))
       '@vue/shared': 3.4.7
+    optionalDependencies:
       typescript: 5.3.3
 
   wcwidth@1.0.1:


### PR DESCRIPTION
we are removing some deprecated internal utilities from `@nuxt/kit`: https://github.com/nuxt/nuxt/pull/28008.

This PR switches to use `mlly`'s `resolvePath`.

discovered via https://github.com/nuxt/ecosystem-ci/actions/runs/9784833674/job/27016597370