### PR TITLE
feat: add `extendComponentMeta`

### DIFF
--- a/src/runtime/composables/extendComponentMeta.ts
+++ b/src/runtime/composables/extendComponentMeta.ts
@@ -1,0 +1,1 @@
+export function extendComponentMeta(_meta: Record<string, any>) { /* Placeholder for extending component meta */ }

--- a/test/fixtures/basic/components/TestComponent.vue
+++ b/test/fixtures/basic/components/TestComponent.vue
@@ -7,6 +7,12 @@
 </template>
 
 <script setup>
+
+extendComponentMeta({
+  hello: 'world',
+  foo: 'bar'
+})
+
 defineProps({
   hello: {
     type: String,

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,4 +1,4 @@
-import nuxtMetaModule from 'nuxt-component-meta'
+import nuxtMetaModule from '../../../src/module'
 
 export default defineNuxtConfig({
   components: {

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -76,4 +76,9 @@ describe('fixtures:basic', async () => {
     expect(component.meta.slots[0].name).toBe('title')
     expect(component.meta.slots[1].name).toBe('default')
   })
+
+  test('Test extendComponentMeta', async () => {
+    const component = await $fetch('/api/component-meta/TestComponent')
+    expect(component.meta).toMatchObject({ hello: 'world', foo: 'bar' })
+  })
 })


### PR DESCRIPTION
This is a quick PoC to discuss about the introduction of a `extendComponentMeta` function to allow users to pass arbitrary objects into component meta data like so:

```vue
<script setup>
extendComponentMeta({ hello: 'world' })
</script>
```

This would allow library authors to pass additional component data to implement devtools more easily.

We might consider implementing a vite plugin to remove the function from the bundle after we parsed it. It might also make more sense to include it in `vue-component-meta` since this is where most of the parsing is done.