### PR TITLE
feat(module): add `component-meta:schema` hook

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div>
-      <TestComponent foo="test" />
+      <TestComponent foo="test" name="test" />
       <TestGlobalComponent />
       <TestTyped :hello="`test`" />
     </div>

--- a/src/module.ts
+++ b/src/module.ts
@@ -86,7 +86,7 @@ export default defineNuxtModule<ModuleOptions>({
           const slots = slotNames
             .trim()
             .split(',')
-            .map(s => s.trim().split(':')[0].trim())
+            .map(s => s.trim().split(':')[0]?.trim())
             .map(s => `<slot name="${s}" />`)
           code = code.replace(/<template>/, `<template>\n${slots.join('\n')}\n`)
         }
@@ -137,7 +137,10 @@ export default defineNuxtModule<ModuleOptions>({
       ...options,
       components: [],
       metaSources: {},
-      transformers
+      transformers,
+      beforeWrite: async (schema: NuxtComponentMeta) => {
+        return await nuxt.callHook('component-meta:schema' as any, schema) || schema
+      }
     }
 
     // Resolve loaded components

--- a/src/parser/meta-parser.ts
+++ b/src/parser/meta-parser.ts
@@ -9,7 +9,6 @@ import type { ComponentMetaParserOptions, NuxtComponentMeta } from '../types/par
 import { defu } from 'defu'
 import { refineMeta } from './utils'
 
-
 export function useComponentMetaParser (
   {
     outputDir = join(process.cwd(), '.component-meta/'),
@@ -21,7 +20,8 @@ export function useComponentMetaParser (
     transformers = [],
     debug = false,
     metaFields,
-    metaSources = {}
+    metaSources = {},
+    beforeWrite
   }: ComponentMetaParserOptions
 ) {
   /**
@@ -116,8 +116,14 @@ export function useComponentMetaParser (
   /**
    * Write the output file.
    */
-  const updateOutput = (content?: string) => {
+  const updateOutput = async (content?: string) => {
     const path = outputPath + '.mjs'
+
+    // Call beforeWrite hook if provided
+    if (beforeWrite && !content) {
+      components = await beforeWrite(components)
+    }
+
     if (!existsSync(dirname(path))) { fs.mkdirSync(dirname(path), { recursive: true }) }
     if (existsSync(path)) { fs.unlinkSync(path) }
     fs.writeFileSync(

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -72,4 +72,5 @@ export interface ModuleOptions {
 export interface ModuleHooks {
   'component-meta:transformers'(data: TransformersHookData): void
   'component-meta:extend'(data: ExtendHookData): void
+  'component-meta:schema'(schema: NuxtComponentMeta): NuxtComponentMeta | Promise<NuxtComponentMeta>
 }

--- a/src/types/parser.ts
+++ b/src/types/parser.ts
@@ -5,6 +5,7 @@ import type { ModuleOptions } from './module'
 export type ComponentMetaParserOptions = Omit<ModuleOptions, 'components' | 'metaSources'> & {
   components: Component[]
   metaSources?: NuxtComponentMeta
+  beforeWrite?: (schema: NuxtComponentMeta) => Promise<NuxtComponentMeta> | NuxtComponentMeta
 }
 export type ComponentData = Omit<Component, 'filePath' | 'shortPath'> & {
   meta: ComponentMeta

--- a/src/utils/unplugin.ts
+++ b/src/utils/unplugin.ts
@@ -1,6 +1,7 @@
 import { createUnplugin } from 'unplugin'
 import { useComponentMetaParser } from '../parser/meta-parser'
-import type { ComponentMetaParser, ComponentMetaParserOptions } from '../parser/meta-parser';
+import type { ComponentMetaParser } from '../parser/meta-parser'
+import type { ComponentMetaParserOptions } from '../types/parser'
 
 type ComponentMetaUnpluginOptions = { parser?: ComponentMetaParser, parserOptions: ComponentMetaParserOptions }
 
@@ -12,14 +13,14 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(({ parser
     return {
       name: 'vite-plugin-nuxt-component-meta',
       enforce: 'post',
-      buildStart () {
+      async buildStart () {
         // avoid parsing meta twice in SSR
         if (_configResolved?.build.ssr) {
           return
         }
 
         instance?.fetchComponents()
-        instance?.updateOutput()
+        await instance?.updateOutput()
       },
       buildEnd () {
         if (!_configResolved?.env.DEV && _configResolved?.env.PROD) {
@@ -32,10 +33,10 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(({ parser
         configResolved (config) {
           _configResolved = config
         },
-        handleHotUpdate ({ file }) {
+        async handleHotUpdate ({ file }) {
           if (instance && Object.entries(instance.components).some(([, comp]: any) => comp.fullPath === file)) {
             instance.fetchComponent(file)
-            instance.updateOutput()
+            await instance.updateOutput()
           }
         }
       }


### PR DESCRIPTION
This PR adds a `component-meta:schema` hook to alter the schema before it is being written on disk.

I need this on the Nuxt UI docs as the `component-meta.mjs` is 13MB (110+ components), by removing the `meta.slots[].schema` (which I don't need) the file size goes down to 5MB:

```ts
import type { NuxtComponentMeta } from 'nuxt-component-meta'

export default defineNuxtConfig({
  hooks: {
    'component-meta:schema': (schema: NuxtComponentMeta) => {
      for (const componentName in schema) {
        const component = schema[componentName]

        if (component?.meta?.slots) {
          for (const slot of component.meta.slots) {
            delete (slot as any).schema
          }
        }
      }
    }
  }
})
```