### PR TITLE
feat: AST-based compiler macro system for extendComponentMeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,11 @@
   "dependencies": {
     "@nuxt/kit": "^4.2.2",
     "citty": "^0.1.6",
+    "jiti": "^2.6.1",
     "mlly": "^1.8.0",
     "ohash": "^2.0.11",
+    "oxc-parser": "^0.129.0",
+    "oxc-walker": "^0.7.0",
     "scule": "^1.3.0",
     "typescript": "^5.9.3",
     "ufo": "^1.6.2",
@@ -68,7 +71,6 @@
     "ajv": "^8.17.1",
     "changelogen": "^0.6.2",
     "eslint": "^9.39.2",
-    "jiti": "^2.6.1",
     "json-schema-to-zod": "^2.7.0",
     "nuxt": "^4.2.2",
     "release-it": "^19.2.3",
@@ -98,6 +100,11 @@
       "unplugin",
       "consola",
       "acorn",
+      "jiti",
+      "magic-string",
+      "mlly",
+      "oxc-parser",
+      "oxc-walker",
       "pkg-types",
       "jsonc-parser"
     ]

--- a/playground/app/components/FilePicker.vue
+++ b/playground/app/components/FilePicker.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <label>{{ label }}</label>
+    <input type="file">
+  </div>
+</template>
+
+<script setup lang="ts">
+import { FieldType } from '../utils/field-type'
+
+extendComponentMeta({
+  category: 'form',
+  defaultType: FieldType.FILE
+})
+
+extendStudioInput({
+  filePath: 'file-picker',
+  multiple: true
+})
+
+defineProps({
+  label: {
+    type: String,
+    default: 'Pick a file'
+  }
+})
+</script>

--- a/playground/app/pages/index.vue
+++ b/playground/app/pages/index.vue
@@ -10,6 +10,15 @@
 
     <pre>{{ specificComponentMeta }}</pre>
 
+    <h2><code>extendMetaFunctions</code> compiler macros (<code>FilePicker</code>)</h2>
+
+    <p>
+      <code>extendComponentMeta</code> resolves an imported const ref, and the custom
+      <code>extendStudioInput</code> macro is wrapped under <code>_studio</code>:
+    </p>
+
+    <pre>{{ filePickerMeta?.meta }}</pre>
+
     <h2>Components from <code>useComponentMeta</code></h2>
 
     <pre>{{ composableData }}</pre>
@@ -26,6 +35,8 @@ import type { NuxtComponentMetaNames } from '#nuxt-component-meta/types'
 const specificComponentName = ref<NuxtComponentMetaNames>('TestContent')
 
 const specificComponentMeta = await useComponentMeta(specificComponentName)
+
+const filePickerMeta = await useComponentMeta('FilePicker' as NuxtComponentMetaNames)
 
 const composableData = await useComponentMeta()
 </script>

--- a/playground/app/utils/field-type.ts
+++ b/playground/app/utils/field-type.ts
@@ -1,0 +1,5 @@
+export const FieldType = {
+  TEXT: 'text',
+  FILE: 'file',
+  NUMBER: 'number'
+} as const

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -23,6 +23,10 @@ export default defineNuxtConfig({
   componentMeta: {
     debug: 2,
     exclude: [/node_modules/i],
+    extendMetaFunctions: [
+      { name: 'extendComponentMeta' },
+      { name: 'extendStudioInput', transform: extracted => ({ _studio: extracted }) }
+    ],
     overrides: {
       TestComponent: {
         props: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
       citty:
         specifier: ^0.1.6
         version: 0.1.6
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       mlly:
         specifier: ^1.8.0
         version: 1.8.0
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
+      oxc-parser:
+        specifier: ^0.129.0
+        version: 0.129.0
+      oxc-walker:
+        specifier: ^0.7.0
+        version: 0.7.0(oxc-parser@0.129.0)
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -63,9 +72,6 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
-      jiti:
-        specifier: ^2.6.1
-        version: 2.6.1
       json-schema-to-zod:
         specifier: ^2.7.0
         version: 2.7.0
@@ -287,14 +293,23 @@ packages:
   '@dxup/unimport@0.1.2':
     resolution: {integrity: sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@es-joy/jsdoccomment@0.78.0':
     resolution: {integrity: sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw==}
@@ -903,6 +918,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1205,36 +1226,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.102.0':
     resolution: {integrity: sha512-DyH/t/zSZHuX4Nn239oBteeMC4OP7B13EyXWX18Qg8aJoZ+lZo90WPGOvhP04zII33jJ7di+vrtAUhsX64lp+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.102.0':
     resolution: {integrity: sha512-CMvzrmOg+Gs44E7TRK/IgrHYp+wwVJxVV8niUrDR2b3SsrCO3NQz5LI+7bM1qDbWnuu5Cl1aiitoMfjRY61dSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.102.0':
     resolution: {integrity: sha512-tZWr6j2s0ddm9MTfWTI3myaAArg9GDy4UgvpF00kMQAjLcGUNhEEQbB9Bd9KtCvDQzaan8HQs0GVWUp+DWrymw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.102.0':
     resolution: {integrity: sha512-0YEKmAIun1bS+Iy5Shx6WOTSj3GuilVuctJjc5/vP8/EMTZ/RI8j0eq0Mu3UFPoT/bMULL3MBXuHuEIXmq7Ddg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.102.0':
     resolution: {integrity: sha512-Ew4QDpEsXoV+pG5+bJpheEy3GH436GBe6ASPB0X27Hh9cQ2gb1NVZ7cY7xJj68+fizwS/PtT8GHoG3uxyH17Pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.102.0':
     resolution: {integrity: sha512-wYPXS8IOu/sXiP3CGHJNPzZo4hfPAwJKevcFH2syvU2zyqUxym7hx6smfcK/mgJBiX7VchwArdGRwrEQKcBSaQ==}
@@ -1259,8 +1286,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-android-arm-eabi@0.129.0':
+    resolution: {integrity: sha512-sG37CfXLlYXdDrggAFO/mKcO4w36piwf862xAZXIuf3nzKhWK1FvW4dqie+06++z+mDto2QeOQSvhyzBeK5jsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.102.0':
     resolution: {integrity: sha512-pD2if3w3cxPvYbsBSTbhxAYGDaG6WVwnqYG0mYRQ142D6SJ6BpNs7YVQrqpRA2AJQCmzaPP5TRp/koFLebagfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.129.0':
+    resolution: {integrity: sha512-DVyLFN2+S0VOhT6lm5++tFqlu3x2Njiby6y5DhTzjV5uRsZWpifsBn6+yjtwAxl105peEjs5BHE3ToBJuQjLTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1271,8 +1310,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.129.0':
+    resolution: {integrity: sha512-QeqThtB8qax4IL+NFBWgshudyKkj5c076L8vyd8PCEx7U1wHyIbH49MEQ5J5iURFhUW5jiFmdnLKEwyOo0GAJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.102.0':
     resolution: {integrity: sha512-Sr2/3K6GEcejY+HgWp5HaxRPzW5XHe9IfGKVn9OhLt8fzVLnXbK5/GjXj7JjMCNKI3G3ZPZDG2Dgm6CX3MaHCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.129.0':
+    resolution: {integrity: sha512-zn5+7nv4DlK4uFgblmhKm6xRV0QUHXOHyIDkjmhxJ53xSA9ahkb3pHNiHesNPXn/nK/VWU+C+Z6JYHdatZBh7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1283,8 +1334,26 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.129.0':
+    resolution: {integrity: sha512-SPTcDBiHWlgRpWFC1jnoi0sBWqCw4DFR+4b8+dV+NAhUu2ONERWyIVIOCfcE9a8BlvZsDCuXf3l/x7wQUs1Rsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.102.0':
     resolution: {integrity: sha512-zRCIOWzLbqhfY4g8KIZDyYfO2Fl5ltxdQI1v2GlePj66vFWRl8cf4qcBGzxKfsH3wCZHAhmWd1Ht59mnrfH/UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.129.0':
+    resolution: {integrity: sha512-Rgc9+WNKLbc+chyDTXyyJ7gbgLo+ve27CrRnmIwGgucGflrBZbutge5jdPPegcgf46RrR4dkBbMCp0/x16mdig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
+    resolution: {integrity: sha512-YtSsJ51VysXqlO8Cs2mWTyXvxBRemTHj4WDQjXwKl0SAxh+CVrEdXrdH+RnjxLj3JCUMFeYuHs5c+/DImfbKkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1294,39 +1363,107 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.129.0':
+    resolution: {integrity: sha512-9oK8iQr9KtgI5JhaJ+5IwiQsXEo6NuasFgovtJGrdK/RxbA0bO4YKRvVY7M+8lozUCVz1U7XrFFODv3emIOPRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.102.0':
     resolution: {integrity: sha512-/XWcmglH/VJ4yKAGTLRgPKSSikh3xciNxkwGiURt8dS30b+3pwc4ZZmudMu0tQ3mjSu0o7V9APZLMpbHK8Bp5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.129.0':
+    resolution: {integrity: sha512-GghE/bf9ZqgqZFxLacgP0ImVD6UiLKQOpvpgUoIsqjopu2ms/+p1L0d0Dv2Sck+8p0FbKS2WE3IjqmIlLbxJgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.129.0':
+    resolution: {integrity: sha512-A2PW0UbERzKGV6fKX1zoe2Tkc1zVcEJSSPW9IUSKbZAPuPe+M5/5hTA+6fQbWmevabe2B3IDky66a1lFGjpBKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.102.0':
     resolution: {integrity: sha512-2jtIq4nswvy6xdqv1ndWyvVlaRpS0yqomLCvvHdCFx3pFXo5Aoq4RZ39kgvFWrbAtpeYSYeAGFnwgnqjx9ftdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.129.0':
+    resolution: {integrity: sha512-omwxd9H+jrl1T72RI666k4ho7Eli2iHdELzf+dL0D+uXThNZXYJCbKjm5rK2hrHmDy4O+NWv7+khBrEkorLsgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
+    resolution: {integrity: sha512-v2hi8id+M8C0uY8uuG2t2a5vr8H9XyHXiHL12yMdMNtgn04nnM/8hlOGuoJuxVc07PhClNiaoSaY2eXehSRa7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.102.0':
     resolution: {integrity: sha512-Yp6HX/574mvYryiqj0jNvNTJqo4pdAsNP2LPBTxlDQ1cU3lPd7DUA4MQZadaeLI8+AGB2Pn50mPuPyEwFIxeFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.129.0':
+    resolution: {integrity: sha512-UXrdDyLh1Obgj5X+IVVXWoo5/FJbFsU8/uLQ/M9lkVUwBUKpRFxNEhzwBNv21qqdKgAh+pr2CCVD8J1JfRPsIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.102.0':
     resolution: {integrity: sha512-R4b0xZpDRhoNB2XZy0kLTSYm0ZmWeKjTii9fcv1Mk3/SIGPrrglwt4U6zEtwK54Dfi4Bve5JnQYduigR/gyDzw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.129.0':
+    resolution: {integrity: sha512-hsL/3/kdX9FGLqOj8DR3Eki4Y6zO1i3+ZHhiPwX0hDt4n+18abkfUzePCv3h8SShprwCmwdxPnlrebZ5+MZ+cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.102.0':
     resolution: {integrity: sha512-xM5A+03Ti3jvWYZoqaBRS3lusvnvIQjA46Fc9aBE/MHgvKgHSkrGEluLWg/33QEwBwxupkH25Pxc1yu97oZCtg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-x64-musl@0.129.0':
+    resolution: {integrity: sha512-kdXvJ4crOeRld3vWl0J0VU4nmnT4pZ3lKGA5tZ1y0UPWsBtElDYd+jsz4lE36tpAbCiWm0M0PG0laUNBSE+Wlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.102.0':
     resolution: {integrity: sha512-AieLlsliblyaTFq7Iw9Nc618tgwV02JT4fQ6VIUd/3ZzbluHIHfPjIXa6Sds+04krw5TvCS8lsegtDYAyzcyhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.129.0':
+    resolution: {integrity: sha512-DusJfcK7EGwf9TEakB+z6SXCLdHGvDZ8U8882bzWb4oVrORHpbkFl9npS7cN3YC2axcVKoktbxZevS1nxVCKFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1336,10 +1473,27 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.129.0':
+    resolution: {integrity: sha512-Iie9CcII+ELSinKFnxTR15xhI9qriVivEhbFh3driRNbzms/5ioDAU0fwe8Mf1FEaz3n2FtiUVX0h0nwKLYk0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.102.0':
     resolution: {integrity: sha512-pqP5UuLiiFONQxqGiUFMdsfybaK1EOK4AXiPlvOvacLaatSEPObZGpyCkAcj9aZcvvNwYdeY9cxGM9IT3togaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
+    resolution: {integrity: sha512-99kH1udLyrts+wGm+u0VhPbogkb2wxc/6J1XMKOpS6Kx5DjBWGRZZfBjfCGI3xKSInpYbZn4TLWLX1Q1GURYwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.129.0':
+    resolution: {integrity: sha512-tmSBR1A4yH697qV291xKyDe4OAWFchJ+cXf2wuipx/vK3n5d5Ej9MVLRtXlIcZ38n8qAjsF0/AnskaYgxM151A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
     os: [win32]
 
   '@oxc-parser/binding-win32-x64-msvc@0.102.0':
@@ -1348,8 +1502,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.129.0':
+    resolution: {integrity: sha512-Z1PbJvkPeLASIUxa3AnrQ5H+vv1K9zC0IGnQqoKfM0ZvsvCSe0d3u5m7d9iuy+HB7GrcElHuwKb0d0qFdtG0iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.102.0':
     resolution: {integrity: sha512-8Skrw405g+/UJPKWJ1twIk3BIH2nXdiVlVNtYT23AXVwpsd79es4K+KYt06Fbnkc5BaTvk/COT2JuCLYdwnCdA==}
+
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@oxc-transform/binding-android-arm64@0.102.0':
     resolution: {integrity: sha512-JLBT7EiExsGmB6LuBBnm6qTfg0rLSxBU+F7xjqy6UXYpL7zhqelGJL7IAq6Pu5UYFT55zVlXXmgzLOXQfpQjXA==}
@@ -1386,36 +1549,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.102.0':
     resolution: {integrity: sha512-I08iWABrN7zakn3wuNIBWY3hALQGsDLPQbZT1mXws7tyiQqJNGe49uS0/O50QhX3KXj+mbRGsmjVXLXGJE1CVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.102.0':
     resolution: {integrity: sha512-9+SYW1ARAF6Oj/82ayoqKRe8SI7O1qvzs3Y0kijvhIqAaaZWcFRjI5DToyWRAbnzTtHlMcSllZLXNYdmxBjFxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.102.0':
     resolution: {integrity: sha512-HV9nTyQw0TTKYPu+gBhaJBioomiM9O4LcGXi+s5IylCGG6imP0/U13q/9xJnP267QFmiWWqnnSFcv0QAWCyh8A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.102.0':
     resolution: {integrity: sha512-4wcZ08mmdFk8OjsnglyeYGu5PW3TDh87AmcMOi7tZJ3cpJjfzwDfY27KTEUx6G880OpjAiF36OFSPwdKTKgp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.102.0':
     resolution: {integrity: sha512-rUHZSZBw0FUnUgOhL/Rs7xJz9KjH2eFur/0df6Lwq/isgJc/ggtBtFoZ+y4Fb8ON87a3Y2gS2LT7SEctX0XdPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.102.0':
     resolution: {integrity: sha512-98y4tccTQ/pA+r2KA/MEJIZ7J8TNTJ4aCT4rX8kWK4pGOko2YsfY3Ru9DVHlLDwmVj7wP8Z4JNxdBrAXRvK+0g==}
@@ -1469,36 +1638,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.4':
     resolution: {integrity: sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.4':
     resolution: {integrity: sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.4':
     resolution: {integrity: sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.4':
     resolution: {integrity: sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.4':
     resolution: {integrity: sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.4':
     resolution: {integrity: sha512-9Cn7GFQevsvKjUKIP4lh7MNwak6z9e1DcOK0g9sJc8O8qRAbnet8uBNg0mMRY+MU+z3a6EEl9u9bhSFKhx5kCw==}
@@ -1681,66 +1856,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -1875,24 +2063,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2402,41 +2594,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2849,6 +3049,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -4700,24 +4901,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5356,12 +5561,21 @@ packages:
     resolution: {integrity: sha512-xMiyHgr2FZsphQ12ZCsXRvSYzmKXCm1ejmyG4GDZIiKOmhyt5iKtWq0klOfFsEQ6jcgbwrUdwcCVYzr1F+h5og==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  oxc-parser@0.129.0:
+    resolution: {integrity: sha512-S6eFI+VLkpyA+/Lf8z6qURjDV6Mgo74SLNznNopHTlQW3hedv2MB/z31kBRuBCCTqZN9HHdva0ojljEhPnBKFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-transform@0.102.0:
     resolution: {integrity: sha512-MR5ohiBS6/kvxRpmUZ3LIDTTJBEC4xLAEZXfYr7vrA0eP7WHewQaNQPFDgT4Bee89TdmVQ5ZKrifGwxLjSyHHw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-walker@0.6.0:
     resolution: {integrity: sha512-BA3hlxq5+Sgzp7TCQF52XDXCK5mwoIZuIuxv/+JuuTzOs2RXkLqWZgZ69d8pJDDjnL7wiREZTWHBzFp/UWH88Q==}
+    peerDependencies:
+      oxc-parser: '>=0.98.0'
+
+  oxc-walker@0.7.0:
+    resolution: {integrity: sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A==}
     peerDependencies:
       oxc-parser: '>=0.98.0'
 
@@ -5693,6 +5907,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -7444,9 +7659,20 @@ snapshots:
 
   '@dxup/unimport@0.1.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -7456,6 +7682,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7910,6 +8141,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -8763,40 +9001,88 @@ snapshots:
   '@oxc-minify/binding-win32-x64-msvc@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.129.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.129.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.129.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.129.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.129.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-s390x-gnu@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-gnu@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.129.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.129.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.102.0':
@@ -8804,13 +9090,31 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.129.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.102.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.129.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.102.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.129.0':
+    optional: true
+
   '@oxc-project/types@0.102.0': {}
+
+  '@oxc-project/types@0.129.0': {}
 
   '@oxc-transform/binding-android-arm64@0.102.0':
     optional: true
@@ -13457,6 +13761,31 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.102.0
       '@oxc-parser/binding-win32-x64-msvc': 0.102.0
 
+  oxc-parser@0.129.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.129.0
+      '@oxc-parser/binding-android-arm64': 0.129.0
+      '@oxc-parser/binding-darwin-arm64': 0.129.0
+      '@oxc-parser/binding-darwin-x64': 0.129.0
+      '@oxc-parser/binding-freebsd-x64': 0.129.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.129.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.129.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.129.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.129.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.129.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.129.0
+      '@oxc-parser/binding-linux-x64-musl': 0.129.0
+      '@oxc-parser/binding-openharmony-arm64': 0.129.0
+      '@oxc-parser/binding-wasm32-wasi': 0.129.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.129.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.129.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.129.0
+
   oxc-transform@0.102.0:
     optionalDependencies:
       '@oxc-transform/binding-android-arm64': 0.102.0
@@ -13479,6 +13808,11 @@ snapshots:
     dependencies:
       magic-regexp: 0.10.0
       oxc-parser: 0.102.0
+
+  oxc-walker@0.7.0(oxc-parser@0.129.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.129.0
 
   p-limit@2.3.0:
     dependencies:

--- a/src/module.ts
+++ b/src/module.ts
@@ -66,7 +66,8 @@ export default defineNuxtModule<ModuleOptions>({
         ]
       }
     },
-    globalsOnly: false
+    globalsOnly: false,
+    extendMetaFunctions: [{ name: 'extendComponentMeta' }]
   }),
   async setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
@@ -171,7 +172,11 @@ export default defineNuxtModule<ModuleOptions>({
         }`,
         'export type NuxtComponentMeta = Record<NuxtComponentMetaNames, ComponentData>',
         'declare const components: NuxtComponentMeta',
-        'export { components as default, components }'
+        'export { components as default, components }',
+        // Global declarations so custom macro names type-check without an import
+        ...(options.extendMetaFunctions || [])
+          .filter(f => f.name !== 'extendComponentMeta')
+          .map(f => `declare function ${f.name}(meta: Record<string, any>): void`)
       ].join('\n'),
       write: true
     })

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2,10 +2,13 @@ import type { ComponentMeta } from 'vue-component-meta'
 import { refineMeta } from "./utils"
 import { tryResolveTypesDeclaration, createMetaChecker  } from "./checker"
 import { defaultTransformers, type ComponentMetaTransformer } from './transformers'
+import { extractMacroMeta } from './macro-extractor'
 import { isAbsolute, join } from "pathe"
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { withBase } from "ufo"
 import { hash } from "crypto"
+import { defu } from 'defu'
+import type { ExtendMetaFunction } from '../types/module'
 
 export interface Options {
   rootDir: string
@@ -15,6 +18,11 @@ export interface Options {
    * Extra transformers to be run on top of component code before parsing.
    */
   transformers?: ComponentMetaTransformer[]
+  /**
+   * Register compiler macro functions that inject custom metadata into components.
+   * @default [{ name: 'extendComponentMeta' }]
+   */
+  extendMetaFunctions?: ExtendMetaFunction[]
 }
 
 export function getComponentMeta(component: string, options?: Options): ComponentMeta {
@@ -61,6 +69,12 @@ export function getComponentMeta(component: string, options?: Options): Componen
   }
 
   const componentMeta = _getComponentMeta(resolvedPath, code, opts)
+
+  const macros = opts.extendMetaFunctions ?? [{ name: 'extendComponentMeta' }]
+  const macroResults = extractMacroMeta(code, macros, resolvedPath)
+  for (const result of macroResults) {
+    Object.assign(componentMeta, defu(componentMeta, result))
+  }
 
   if (cachePath) {
     const cache = JSON.stringify({ cachedAt: Date.now(), ...componentMeta })

--- a/src/parser/macro-extractor.ts
+++ b/src/parser/macro-extractor.ts
@@ -1,0 +1,199 @@
+import { parseSync } from 'oxc-parser'
+import { walk, isBindingIdentifier } from 'oxc-walker'
+import MagicString from 'magic-string'
+import { createJiti } from 'jiti'
+import { findStaticImports, parseStaticImport } from 'mlly'
+import type { ExtendMetaFunction } from '../types/module'
+
+const SCRIPT_BLOCK_RE = /<script\b(?:"[^"]*"|'[^']*'|[^>])*>([\s\S]*?)<\/script>/gi
+
+/** For .vue files, extract and concatenate all script block contents. */
+function extractScriptContent(code: string, filename: string): string {
+  if (!filename.endsWith('.vue')) return code
+  const blocks: string[] = []
+  let match: RegExpExecArray | null
+  SCRIPT_BLOCK_RE.lastIndex = 0
+  while ((match = SCRIPT_BLOCK_RE.exec(code))) {
+    blocks.push(match[1]!)
+  }
+  return blocks.join('\n')
+}
+
+/** Collect all identifier names referenced (not bound) in an AST node. */
+function collectReferencedIdentifiers(node: any): Set<string> {
+  const names = new Set<string>()
+  walk(node, {
+    enter(n: any, parent: any) {
+      if (n.type !== 'Identifier') return
+      if (isBindingIdentifier(n, parent)) return
+      if (parent?.type === 'MemberExpression' && parent.property === n && !parent.computed) return
+      if (parent?.type === 'Property' && parent.key === n && !parent.computed) return
+      names.add(n.name)
+    }
+  })
+  return names
+}
+
+/**
+ * Build a self-contained ESM module string for the macro argument,
+ * including the import statements its expression references.
+ */
+function buildEvalModule(content: string, argNode: any): string {
+  const referencedNames = collectReferencedIdentifiers(argNode)
+  const argSource = content.slice(argNode.start, argNode.end)
+
+  if (!referencedNames.size) {
+    return `export default (${argSource})`
+  }
+
+  const neededImports: string[] = []
+  for (const rawImport of findStaticImports(content)) {
+    const parsed = parseStaticImport(rawImport)
+    const importedNames = [
+      parsed.defaultImport,
+      parsed.namespacedImport,
+      ...Object.values(parsed.namedImports ?? {}),
+    ].filter(Boolean) as string[]
+
+    if (importedNames.some(name => referencedNames.has(name))) {
+      neededImports.push(rawImport.code)
+    }
+  }
+
+  return [...neededImports, `export default (${argSource})`].join('\n')
+}
+
+/**
+ * Evaluate a macro argument to a plain object or array.
+ * Returns undefined if evaluation fails or the result is not a plain value.
+ */
+function evaluateMacroArgument(content: string, argNode: any, filename: string): Record<string, any> | any[] | undefined {
+  const moduleSource = buildEvalModule(content, argNode)
+
+  try {
+    const jiti = createJiti(filename, { moduleCache: false, fsCache: false })
+    const result = jiti.evalModule(moduleSource, { filename })
+
+    const value = (result as any)?.default ?? result
+    if (value === null || value === undefined) return undefined
+    if (Array.isArray(value)) return value as any[]
+    if (typeof value !== 'object') return undefined
+
+    // Reject non-plain objects (class instances, etc.)
+    const proto = Object.getPrototypeOf(value)
+    if (proto !== Object.prototype && proto !== null) return undefined
+
+    return value as Record<string, any>
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Extract metadata from all registered macro calls in `code`,
+ * one object per matching call, with transforms applied.
+ */
+export function extractMacroMeta(
+  code: string,
+  macros: ExtendMetaFunction[],
+  filename = 'component.vue'
+): Record<string, any>[] {
+  if (!macros.length) return []
+
+  const macroNames = new Set(macros.map(m => m.name))
+  if (![...macroNames].some(name => code.includes(name))) return []
+
+  const content = extractScriptContent(code, filename)
+  if (!content.trim()) return []
+
+  // Use .ts extension so oxc parses TypeScript syntax correctly
+  const parseFilename = filename.endsWith('.vue') ? filename.replace('.vue', '.ts') : filename
+
+  let program: any
+  try {
+    program = parseSync(parseFilename, content).program
+  } catch {
+    return []
+  }
+
+  const results: Record<string, any>[] = []
+
+  walk(program, {
+    enter(node: any) {
+      if (
+        node.type !== 'ExpressionStatement'
+        || node.expression.type !== 'CallExpression'
+        || node.expression.callee.type !== 'Identifier'
+      ) return
+
+      const macroName: string = node.expression.callee.name
+      if (!macroNames.has(macroName)) return
+
+      const args = node.expression.arguments
+      if (!args.length) return
+      const argType = args[0].type
+      if (argType !== 'ObjectExpression' && argType !== 'ArrayExpression') return
+
+      const extracted = evaluateMacroArgument(content, args[0], parseFilename)
+      if (!extracted) return
+
+      const macro = macros.find(m => m.name === macroName)!
+
+      if (Array.isArray(extracted)) {
+        // Arrays require a transform to produce a mergeable object
+        if (!macro.transform) return
+        results.push(macro.transform(extracted))
+      } else {
+        results.push(macro.transform ? macro.transform(extracted) : extracted)
+      }
+    }
+  })
+
+  return results
+}
+
+/**
+ * Strip all registered macro call statements from `code`.
+ * Returns code + sourcemap, or `undefined` if nothing was changed.
+ */
+export function stripMacroCalls(
+  code: string,
+  macroNames: string[],
+  filename = 'component.js'
+): { code: string; map: any } | undefined {
+  if (!macroNames.length) return undefined
+  if (!macroNames.some(name => code.includes(name))) return undefined
+
+  let program: any
+  try {
+    program = parseSync(filename, code).program
+  } catch {
+    return undefined
+  }
+
+  const nameSet = new Set(macroNames)
+  const s = new MagicString(code)
+  let changed = false
+
+  walk(program, {
+    enter(node: any) {
+      if (
+        node.type !== 'ExpressionStatement'
+        || node.expression.type !== 'CallExpression'
+        || node.expression.callee.type !== 'Identifier'
+      ) return
+
+      if (!nameSet.has(node.expression.callee.name)) return
+
+      s.remove(node.start, node.end)
+      changed = true
+    }
+  })
+
+  if (!changed) return undefined
+
+  return {
+    code: s.toString(),
+    map: s.generateMap({ hires: true })
+  }
+}

--- a/src/parser/meta-parser.ts
+++ b/src/parser/meta-parser.ts
@@ -8,6 +8,7 @@ import { hash } from 'ohash'
 import type { ComponentMetaParserOptions, NuxtComponentMeta } from '../types/parser'
 import { defu } from 'defu'
 import { refineMeta } from './utils'
+import { extractMacroMeta } from './macro-extractor'
 import { tryResolveTypesDeclaration, createMetaChecker  } from './checker'
 import { optimiseJSON } from './optimiser'
 
@@ -21,6 +22,7 @@ export function useComponentMetaParser (
     exclude = [],
     overrides = {},
     transformers = [],
+    extendMetaFunctions = [{ name: 'extendComponentMeta' }],
     debug = false,
     metaFields,
     metaSources = {},
@@ -206,9 +208,10 @@ export function useComponentMetaParser (
         }
       )
 
-      const extendComponentMetaMatch = code.match(/extendComponentMeta\((\{[\s\S]*?\})\)/);
-      const extendedComponentMeta =  extendComponentMetaMatch?.length ? eval(`(${extendComponentMetaMatch[1]})`) : null
-      component.meta = defu(component.meta, extendedComponentMeta)
+      const macroResults = extractMacroMeta(code, extendMetaFunctions, resolvedPath)
+      for (const result of macroResults) {
+        component.meta = defu(component.meta, result)
+      }
 
       components[component.pascalName] = component
     } catch {

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -3,6 +3,20 @@ import type { ComponentsDir, ComponentsOptions } from '@nuxt/schema'
 import type { TransformersHookData, ExtendHookData, NuxtComponentMeta } from '.'
 import type { JsonSchema } from './schema'
 
+export interface ExtendMetaFunction {
+  /** The function name to recognize as a compiler macro */
+  name: string
+  /**
+   * Optional transform applied to the extracted object before merging into component.meta.
+   * Use this to wrap the argument under a namespace key.
+   *
+   * @example
+   * // extendProps({ filePath: 'file-picker' }) → { _studio: { filePath: 'file-picker' } }
+   * transform: (extracted) => ({ _studio: extracted })
+   */
+  transform?: (extracted: Record<string, any> | any[]) => Record<string, any>
+}
+
 export interface ModuleOptions {
   /**
    * Directory where files metas are outputed upon parsing.
@@ -93,6 +107,22 @@ export interface ModuleOptions {
    * It can be a path to a file exporting a default object of components definitions or an object of components definitions.
    */
   metaSources?: (string | Partial<NuxtComponentMeta>)[]
+  /**
+   * Register compiler macro functions that inject custom metadata into components.
+   * Each entry defines a function name and an optional transform hook applied to the extracted argument.
+   *
+   * Calls are stripped from browser output (no runtime cost) and extracted at build time via AST parsing.
+   * Macro arguments can be static object/array literals and may reference imported constants.
+   *
+   * @default [{ name: 'extendComponentMeta' }]
+   *
+   * @example
+   * extendMetaFunctions: [
+   *   { name: 'extendComponentMeta' },
+   *   { name: 'extendProps', transform: (extracted) => ({ _studio: extracted }) }
+   * ]
+   */
+  extendMetaFunctions?: ExtendMetaFunction[]
 }
 
 export interface ModuleHooks {

--- a/src/utils/unplugin.ts
+++ b/src/utils/unplugin.ts
@@ -2,6 +2,7 @@ import { createUnplugin } from 'unplugin'
 import { useComponentMetaParser } from '../parser/meta-parser'
 import type { ComponentMetaParser } from '../parser/meta-parser'
 import type { ComponentMetaParserOptions } from '../types/parser'
+import { stripMacroCalls } from '../parser/macro-extractor'
 
 type ComponentMetaUnpluginOptions = { parser?: ComponentMetaParser, parserOptions: ComponentMetaParserOptions }
 
@@ -10,9 +11,19 @@ export const metaPlugin = createUnplugin<ComponentMetaUnpluginOptions>(({ parser
     let instance = parser || useComponentMetaParser(parserOptions)
     let _configResolved: any
 
+    const macroNames = (parserOptions.extendMetaFunctions || [{ name: 'extendComponentMeta' }]).map(f => f.name)
+
     return {
       name: 'vite-plugin-nuxt-component-meta',
       enforce: 'post',
+      transformInclude (id: string) {
+        return /\.(vue|ts|js|tsx|jsx)(\?|$)/.test(id)
+      },
+      transform (code: string, id: string) {
+        if (!macroNames.some(name => code.includes(name))) return
+        const filename = id.split('?')[0]!
+        return stripMacroCalls(code, macroNames, filename)
+      },
       async buildStart () {
         // avoid parsing meta twice in SSR
         if (_configResolved?.build.ssr) {

--- a/test/fixtures/basic/app/components/TestExtendConstRef.vue
+++ b/test/fixtures/basic/app/components/TestExtendConstRef.vue
@@ -1,0 +1,9 @@
+<template>
+  <div />
+</template>
+
+<script setup>
+import { InputType } from '../utils/InputType'
+extendComponentMeta({ inputType: InputType.FILE })
+defineProps({ title: String })
+</script>

--- a/test/fixtures/basic/app/components/TestExtendProps.vue
+++ b/test/fixtures/basic/app/components/TestExtendProps.vue
@@ -1,0 +1,8 @@
+<template>
+  <div />
+</template>
+
+<script setup>
+extendProps({ filePath: 'file-picker' })
+defineProps({ title: String })
+</script>

--- a/test/fixtures/basic/app/utils/InputType.ts
+++ b/test/fixtures/basic/app/utils/InputType.ts
@@ -1,0 +1,4 @@
+export const InputType = {
+  FILE: 'file',
+  TEXT: 'text'
+} as const

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -13,5 +13,11 @@ export default defineNuxtConfig({
   },
   modules: [
     nuxtMetaModule
-  ]
+  ],
+  componentMeta: {
+    extendMetaFunctions: [
+      { name: 'extendComponentMeta' },
+      { name: 'extendProps', transform: (extracted: Record<string, any>) => ({ _studio: extracted }) }
+    ]
+  }
 })

--- a/test/macro-extractor.test.ts
+++ b/test/macro-extractor.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'vitest'
+import { join } from 'path'
+import { extractMacroMeta } from '../src/parser/macro-extractor'
+
+describe('extractMacroMeta', () => {
+  const filename = join(__dirname, 'component.ts')
+
+  test('extracts a plain object argument', () => {
+    const code = `extendComponentMeta({ hello: 'world', foo: 'bar' })`
+    const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], filename)
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual({ hello: 'world', foo: 'bar' })
+  })
+
+  test('applies transform to object argument', () => {
+    const code = `extendProps({ filePath: 'file-picker' })`
+    const results = extractMacroMeta(code, [
+      { name: 'extendProps', transform: extracted => ({ _studio: extracted }) }
+    ], filename)
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual({ _studio: { filePath: 'file-picker' } })
+  })
+
+  test('extracts array argument when transform is provided', () => {
+    const code = `defineStudioInputs([{ name: 'filePath', type: 'file' }, { name: 'label', type: 'string' }])`
+    const results = extractMacroMeta(code, [
+      { name: 'defineStudioInputs', transform: (inputs: any) => ({ _studio: { inputs } }) }
+    ], filename)
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual({
+      _studio: {
+        inputs: [
+          { name: 'filePath', type: 'file' },
+          { name: 'label', type: 'string' },
+        ]
+      }
+    })
+  })
+
+  test('skips array argument when no transform is configured', () => {
+    const code = `extendComponentMeta([{ foo: 'bar' }])`
+    const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], filename)
+    expect(results).toHaveLength(0)
+  })
+
+  test('returns nothing for unknown macro names', () => {
+    const code = `unknownMacro({ foo: 'bar' })`
+    const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], filename)
+    expect(results).toHaveLength(0)
+  })
+
+  test('handles empty macro list', () => {
+    const code = `extendComponentMeta({ foo: 'bar' })`
+    const results = extractMacroMeta(code, [], filename)
+    expect(results).toHaveLength(0)
+  })
+
+  test('extracts multiple macro calls', () => {
+    const code = [
+      `extendComponentMeta({ hello: 'world' })`,
+      `extendProps({ filePath: 'file-picker' })`,
+    ].join('\n')
+    const results = extractMacroMeta(code, [
+      { name: 'extendComponentMeta' },
+      { name: 'extendProps', transform: extracted => ({ _studio: extracted }) }
+    ], filename)
+    expect(results).toHaveLength(2)
+    expect(results[0]).toEqual({ hello: 'world' })
+    expect(results[1]).toEqual({ _studio: { filePath: 'file-picker' } })
+  })
+
+  describe('.vue script extraction', () => {
+    const vueFilename = join(__dirname, 'component.vue')
+
+    test('extracts macro from a simple script setup block', () => {
+      const code = [
+        `<script setup lang="ts">`,
+        `extendComponentMeta({ hello: 'world' })`,
+        `</script>`,
+        `<template><div /></template>`,
+      ].join('\n')
+      const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], vueFilename)
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({ hello: 'world' })
+    })
+
+    test('extracts macro from a generic script setup block (attribute contains >)', () => {
+      const code = [
+        `<script setup lang="ts" generic="T extends Record<string, unknown>">`,
+        `extendComponentMeta({ hello: 'world' })`,
+        `</script>`,
+        `<template><div /></template>`,
+      ].join('\n')
+      const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], vueFilename)
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({ hello: 'world' })
+    })
+
+    test('extracts macro across multiple script blocks', () => {
+      const code = [
+        `<script lang="ts">`,
+        `export default { name: 'Foo' }`,
+        `</script>`,
+        `<script setup lang="ts">`,
+        `extendComponentMeta({ hello: 'world' })`,
+        `</script>`,
+        `<template><div /></template>`,
+      ].join('\n')
+      const results = extractMacroMeta(code, [{ name: 'extendComponentMeta' }], vueFilename)
+      expect(results).toHaveLength(1)
+      expect(results[0]).toEqual({ hello: 'world' })
+    })
+  })
+})

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -81,4 +81,14 @@ describe('fixtures:basic', async () => {
     const component = await $fetch('/api/component-meta/TestComponent')
     expect(component.meta).toMatchObject({ hello: 'world', foo: 'bar' })
   })
+
+  test('Test extendProps with transform', async () => {
+    const component = await $fetch('/api/component-meta/TestExtendProps')
+    expect(component.meta._studio).toMatchObject({ filePath: 'file-picker' })
+  })
+
+  test('Test extendComponentMeta with imported const ref', async () => {
+    const component = await $fetch('/api/component-meta/TestExtendConstRef')
+    expect(component.meta.inputType).toBe('file')
+  })
 })


### PR DESCRIPTION
## Summary

- Replaces the fragile regex+eval hack for `extendComponentMeta` with proper AST-based parsing via `oxc-parser` + `oxc-walker`
- Adds `extendMetaFunctions` module option to register named compiler macros, each with an optional `transform` hook
- Macro calls are stripped from browser output by the Vite plugin (true zero-runtime compiler macros)
- Custom macro names get auto-generated `declare function` type declarations

## New API

```ts
// nuxt.config.ts
componentMeta: {
  extendMetaFunctions: [
    { name: 'extendComponentMeta' },
    { name: 'extendProps', transform: (extracted) => ({ _studio: extracted }) }
  ]
}
```

```vue
<!-- In a component -->
<script setup>
extendProps({ filePath: 'file-picker' })
</script>
```

Produces `component.meta._studio = { filePath: 'file-picker' }` — with no runtime cost.

## Changes

- `src/parser/macro-extractor.ts` — new file: `extractMacroMeta()` and `stripMacroCalls()` using oxc AST
- `src/types/module.ts` — new `ExtendMetaFunction` interface, `extendMetaFunctions` option
- `src/parser/meta-parser.ts` — replaces regex+eval with `extractMacroMeta`
- `src/utils/unplugin.ts` — adds Vite `transform` hook to strip macro calls
- `src/module.ts` — wires defaults, generates type declarations for custom macro names
- `src/parser/index.ts` — adds `extendMetaFunctions` support to standalone parser

## Test plan

- [x] Existing `extendComponentMeta` test passes (backward compatible)
- [x] New `extendProps` with transform test passes (`meta._studio.filePath === 'file-picker'`)
- [ ] Verify macro calls are absent from browser bundle output

🤖 Generated with [Claude Code](https://claude.com/claude-code)